### PR TITLE
Stop releases on mergify builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
   agent:
 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'mergify'
     needs: test
     steps:
       - name: checkout
@@ -73,7 +73,7 @@ jobs:
   agent-kafka:
 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'mergify'
     needs: test
     steps:
       - name: checkout
@@ -138,7 +138,7 @@ jobs:
   collector-lite:
 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'mergify'
     needs: test
     steps:
       - name: checkout
@@ -203,7 +203,7 @@ jobs:
   collector:
 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'mergify'
     needs: test
     steps:
       - name: checkout
@@ -265,7 +265,7 @@ jobs:
   libraries:
 
     runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && author != 'mergify'
+    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'mergify'
     needs: test
 
     steps:


### PR DESCRIPTION
Dependency updates happen fairly frequently, this should
stop so many releases ending up in maven central that are
just dependency updates. PRs contributions should be
unaffected.