### PR TITLE
More preparations for Scala 3

### DIFF
--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Lift.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Lift.scala
@@ -7,8 +7,8 @@ trait Lift[Low[_], F[_]] extends ContextRoot { self =>
   def F: Monad[F]
 
   def lift[A](la: Low[A]): F[A]
-  def liftK: Low ~> F = new ~>[Low, F] {
-    override def apply[A](fa: Low[A]): F[A] = lift(fa)
+  def liftK: Low ~> F = new (Low ~> F) {
+    override def apply[A](la: Low[A]): F[A] = lift(la)
   }
 
   def mapK[G[_]: Monad](fk: F ~> G): Lift[Low, G] = new Lift[Low, G] {

--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Lift.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Lift.scala
@@ -7,7 +7,9 @@ trait Lift[Low[_], F[_]] extends ContextRoot { self =>
   def F: Monad[F]
 
   def lift[A](la: Low[A]): F[A]
-  def liftK: Low ~> F = λ[Low ~> F](lift(_))
+  def liftK: Low ~> F = new ~>[Low, F] {
+    override def apply[A](fa: Low[A]): F[A] = lift(fa)
+  }
 
   def mapK[G[_]: Monad](fk: F ~> G): Lift[Low, G] = new Lift[Low, G] {
     def Low: Monad[Low] = self.Low

--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Local.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Local.scala
@@ -5,12 +5,12 @@ import io.janstenpickle.trace4cats.base.optics.Lens
 
 trait Local[F[_], R] extends Ask[F, R] { self =>
   def local[A](fa: F[A])(f: R => R): F[A]
-  def localK(f: R => R): F ~> F = new ~>[F, F] {
+  def localK(f: R => R): F ~> F = new (F ~> F) {
     override def apply[A](fa: F[A]): F[A] = local(fa)(f)
   }
 
   def scope[A](fa: F[A])(r: R): F[A] = local(fa)(_ => r)
-  def scopeK(r: R): F ~> F = new ~>[F, F] {
+  def scopeK(r: R): F ~> F = new (F ~> F) {
     override def apply[A](fa: F[A]): F[A] = scope(fa)(r)
   }
 

--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Local.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Local.scala
@@ -5,10 +5,14 @@ import io.janstenpickle.trace4cats.base.optics.Lens
 
 trait Local[F[_], R] extends Ask[F, R] { self =>
   def local[A](fa: F[A])(f: R => R): F[A]
-  def localK(f: R => R): F ~> F = λ[F ~> F](local(_)(f))
+  def localK(f: R => R): F ~> F = new ~>[F, F] {
+    override def apply[A](fa: F[A]): F[A] = local(fa)(f)
+  }
 
   def scope[A](fa: F[A])(r: R): F[A] = local(fa)(_ => r)
-  def scopeK(r: R): F ~> F = λ[F ~> F](scope(_)(r))
+  def scopeK(r: R): F ~> F = new ~>[F, F] {
+    override def apply[A](fa: F[A]): F[A] = scope(fa)(r)
+  }
 
   def focus[R1](lens: Lens[R, R1]): Local[F, R1] = new Local[F, R1] {
     def F: Monad[F] = self.F

--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Provide.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Provide.scala
@@ -5,7 +5,9 @@ import cats.{~>, Monad}
 trait Provide[Low[_], F[_], R] extends Local[F, R] with Unlift[Low, F] { self =>
   def provide[A](fa: F[A])(r: R): Low[A]
 
-  def provideK(r: R): F ~> Low = λ[F ~> Low](provide(_)(r))
+  def provideK(r: R): F ~> Low = new ~>[F, Low] {
+    override def apply[A](fa: F[A]): Low[A] = provide(fa)(r)
+  }
 
   override def askUnlift: F[F ~> Low] = access(provideK)
 

--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Provide.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Provide.scala
@@ -5,7 +5,7 @@ import cats.{~>, Monad}
 trait Provide[Low[_], F[_], R] extends Local[F, R] with Unlift[Low, F] { self =>
   def provide[A](fa: F[A])(r: R): Low[A]
 
-  def provideK(r: R): F ~> Low = new ~>[F, Low] {
+  def provideK(r: R): F ~> Low = new (F ~> Low) {
     override def apply[A](fa: F[A]): Low[A] = provide(fa)(r)
   }
 

--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/optics/Getter.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/optics/Getter.scala
@@ -1,6 +1,6 @@
 package io.janstenpickle.trace4cats.base.optics
 
-trait Getter[S, A] { self =>
+@FunctionalInterface trait Getter[S, A] { self =>
   def get(s: S): A
 
   def composeGetter[T](other: Getter[T, S]): Getter[T, A] = s => self.get(other.get(s))

--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/Span.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/Span.scala
@@ -26,7 +26,7 @@ trait Span[F[_]] {
     Span.mapK(fk)(this)
 }
 
-case class RefSpan[F[_]: Sync] private (
+case class RefSpan[F[_]: Sync] private[trace4cats] (
   context: SpanContext,
   name: String,
   kind: SpanKind,
@@ -73,7 +73,7 @@ case class RefSpan[F[_]: Sync] private (
 
 }
 
-case class EmptySpan[F[_]: Sync] private (context: SpanContext) extends Span[F] {
+case class EmptySpan[F[_]: Sync] private[trace4cats] (context: SpanContext) extends Span[F] {
   override def put(key: String, value: AttributeValue): F[Unit] = Applicative[F].unit
   override def putAll(fields: (String, AttributeValue)*): F[Unit] = Applicative[F].unit
   override def putAll(fields: Map[String, AttributeValue]): F[Unit] = Applicative[F].unit
@@ -88,7 +88,7 @@ case class EmptySpan[F[_]: Sync] private (context: SpanContext) extends Span[F] 
   override def child(name: String, kind: SpanKind, errorHandler: ErrorHandler): Resource[F, Span[F]] = child(name, kind)
 }
 
-case class NoopSpan[F[_]: Applicative] private (context: SpanContext) extends Span[F] {
+case class NoopSpan[F[_]: Applicative] private[trace4cats] (context: SpanContext) extends Span[F] {
   override def put(key: String, value: AttributeValue): F[Unit] = Applicative[F].unit
   override def putAll(fields: (String, AttributeValue)*): F[Unit] = Applicative[F].unit
   override def putAll(fields: Map[String, AttributeValue]): F[Unit] = Applicative[F].unit

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3SingleToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3SingleToHeadersSpec.scala
@@ -11,7 +11,7 @@ class B3SingleToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChe
 
   val b3Single = new B3SingleToHeaders
 
-  it should "encode and decode span context headers" in forAll { spanContext: SpanContext =>
+  it should "encode and decode span context headers" in forAll { (spanContext: SpanContext) =>
     assert(
       Eq.eqv(
         b3Single.toContext(b3Single.fromContext(spanContext)),

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3ToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/B3ToHeadersSpec.scala
@@ -20,7 +20,7 @@ class B3ToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks wi
 
   val b3 = new B3ToHeaders
 
-  it should "encode and decode span context headers" in forAll { spanContext: SpanContext =>
+  it should "encode and decode span context headers" in forAll { (spanContext: SpanContext) =>
     assert(
       Eq.eqv(
         b3.toContext(b3.fromContext(spanContext)),

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/EnvoyToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/EnvoyToHeadersSpec.scala
@@ -13,7 +13,7 @@ class EnvoyToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks
 
   val envoy = new EnvoyToHeaders
 
-  it should "encode and decode span context headers" in forAll { spanContext: SpanContext =>
+  it should "encode and decode span context headers" in forAll { (spanContext: SpanContext) =>
     assert(
       Eq.eqv(
         envoy.toContext(envoy.fromContext(spanContext)),

--- a/modules/core/src/test/scala/io/janstenpickle/trace4cats/W3cToHeadersSpec.scala
+++ b/modules/core/src/test/scala/io/janstenpickle/trace4cats/W3cToHeadersSpec.scala
@@ -19,7 +19,7 @@ class W3cToHeadersSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks w
 
   val w3c = new W3cToHeaders
 
-  it should "encode and decode span context headers" in forAll { spanContext: SpanContext =>
+  it should "encode and decode span context headers" in forAll { (spanContext: SpanContext) =>
     assert(
       Eq[Option[SpanContext]]
         .eqv(w3c.toContext(w3c.fromContext(spanContext)), Some(spanContext.copy(parent = None, isRemote = true)))


### PR DESCRIPTION
Rewrites lambda syntax for FunctionK so that these snippets cross compile on Scala 2 & 3. Fixes a visibility issue with span implementations and adds parentheses around lambda parameters as Scala 3 requires them.