### PR TITLE
Change Mergify rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,7 +10,7 @@ pull_request_rules:
       label:
         add: [ dependency-update ]
 
-  - name: Automatically merge Stewards' PRs
+  - name: Merge Stewards' PRs
     conditions:
       - or:
           - author=scala-steward
@@ -23,10 +23,34 @@ pull_request_rules:
                   - files=project/plugins.sbt
           - body~=labels:.*semver-patch
           - "#approved-reviews-by>=1"
-      - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
-      - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
-      - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
-      - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
+      - and:
+          - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
+          - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
+          - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
+          - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
     actions:
       merge:
-        method: merge
+        method: rebase
+
+  - name: Merge PRs via Mergify to skip the release step on CI
+    conditions:
+      - or:
+          - author=janstenpickle
+          - author=catostrophe
+      - and:
+          - label=skip-release
+          - label=ready-to-merge
+      - and:
+          - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
+          - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
+          - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
+          - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
+    actions:
+      merge:
+        method: rebase
+
+  - name: Delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,59 +1,29 @@
 pull_request_rules:
-  - name: request reviews and label scala-steward's PRs
+  - name: Request reviews and label Stewards' PRs
     conditions:
-      - author=scala-steward
+      - or:
+        - author=scala-steward
+        - author=trace4cats-steward[bot]
     actions:
       request_reviews:
         users: [janstenpickle, catostrophe]
       label:
         add: [dependency-update]
 
-  - name: automatically merge scala-steward's PRs affecting project plugins
+  - name: Automatically merge Stewards' PRs
     conditions:
-      - author=scala-steward
-      - status-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
-      - status-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
-      - status-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
-      - status-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
-      - "#files=1"
-      - files=project/plugins.sbt
-    actions:
-      merge:
-        method: merge
-
-  - name: automatically merge scala-steward's PRs affecting project build properties
-    conditions:
-      - author=scala-steward
-      - status-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
-      - status-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
-      - status-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
-      - status-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
-      - "#files=1"
-      - files=project/build.properties
-    actions:
-      merge:
-        method: merge
-
-  - name: automatically merge scala-steward's PRs updating semver-patch versions
-    conditions:
-      - author=scala-steward
-      - status-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
-      - status-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
-      - status-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
-      - status-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
-      - body~=labels:.*semver-patch
-    actions:
-      merge:
-        method: merge
-
-  - name: automatically merge other scala-steward's PRs reviewed by 1 maintainer
-    conditions:
-      - author=scala-steward
-      - status-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
-      - status-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
-      - status-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
-      - status-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
-      - "#approved-reviews-by>=1"
-    actions:
-      merge:
-        method: merge
+      - or:
+        - author=scala-steward
+        - author=trace4cats-steward[bot]
+      - or:
+        - and:
+          - "#files=1"
+          - or:
+            - files=project/build.properties
+            - files=project/plugins.sbt
+        - body~=labels:.*semver-patch
+        - "#approved-reviews-by>=1"          
+      - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
+      - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
+      - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
+      - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -27,3 +27,6 @@ pull_request_rules:
       - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
       - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
       - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
+    actions:
+      merge:
+        method: merge

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,27 +2,27 @@ pull_request_rules:
   - name: Request reviews and label Stewards' PRs
     conditions:
       - or:
-        - author=scala-steward
-        - author=trace4cats-steward[bot]
+          - author=scala-steward
+          - author=trace4cats-steward[bot]
     actions:
       request_reviews:
-        users: [janstenpickle, catostrophe]
+        users: [ janstenpickle, catostrophe ]
       label:
-        add: [dependency-update]
+        add: [ dependency-update ]
 
   - name: Automatically merge Stewards' PRs
     conditions:
       - or:
-        - author=scala-steward
-        - author=trace4cats-steward[bot]
+          - author=scala-steward
+          - author=trace4cats-steward[bot]
       - or:
-        - and:
-          - "#files=1"
-          - or:
-            - files=project/build.properties
-            - files=project/plugins.sbt
-        - body~=labels:.*semver-patch
-        - "#approved-reviews-by>=1"          
+          - and:
+              - "#files=1"
+              - or:
+                  - files=project/build.properties
+                  - files=project/plugins.sbt
+          - body~=labels:.*semver-patch
+          - "#approved-reviews-by>=1"
       - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.8\)
       - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
       - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)


### PR DESCRIPTION
Changes:
- use `-or` combinator for grouping similar rules
- add `trace4cats-steward[bot]`
- rename `status-success` to `check-success` as per https://github.com/Mergifyio/mergify-engine/pull/1455
- add "remove branch after merge"
- add a rule for auto-merging PRs via Mergify to skip release

All condition combinations are checked via Mergify config editor on real PRs by Steward.