### PR TITLE
Use custom Arbitrary[Instant] instance again

### DIFF
--- a/modules/testkit/src/main/scala/io/janstenpickle/trace4cats/test/ArbitraryInstances.scala
+++ b/modules/testkit/src/main/scala/io/janstenpickle/trace4cats/test/ArbitraryInstances.scala
@@ -103,8 +103,8 @@ trait ArbitraryInstances extends ArbitraryAttributeValues {
         context <- Gen.resize(size / 5, spanContextArb.arbitrary)
         name <- stringArb.arbitrary
         kind <- spanKindArb.arbitrary
-        start <- Arbitrary.arbInstant.arbitrary
-        end <- Arbitrary.arbInstant.arbitrary
+        start <- instantArb.arbitrary
+        end <- instantArb.arbitrary.suchThat(_.isAfter(start))
         attributes <- Gen.resize(size / 3, Gen.mapOf(Gen.zip(stringArb.arbitrary, attributeValueArb.arbitrary)))
         status <- spanStatusArb.arbitrary
         links <- Gen.option(


### PR DESCRIPTION
And ensure invariant that a span always ends after it starts.

Found in https://github.com/trace4cats/trace4cats-datadog/pull/15, fixes that problem at least locally.