### PR TITLE
Throwable.getMessage can return null

### DIFF
--- a/modules/core/src/main/scala/io/janstenpickle/trace4cats/Span.scala
+++ b/modules/core/src/main/scala/io/janstenpickle/trace4cats/Span.scala
@@ -139,7 +139,7 @@ object Span {
             case (span, ExitCase.Succeeded) => span.end
             case (span, ExitCase.Canceled) => span.end(SpanStatus.Cancelled)
             case (span, ExitCase.Errored(th)) =>
-              val end = span.end(SpanStatus.Internal(th.getMessage))
+              val end = span.end(SpanStatus.Internal(Option(th.getMessage).getOrElse(th.toString)))
 
               errorHandler.lift(th) match {
                 case Some(HandledError.Status(spanStatus)) => span.end(spanStatus)

--- a/modules/meta/src/main/scala/io/janstenpickle/trace4cats/meta/MetaTraceUtil.scala
+++ b/modules/meta/src/main/scala/io/janstenpickle/trace4cats/meta/MetaTraceUtil.scala
@@ -34,7 +34,7 @@ object MetaTraceUtil {
         Clock[F].realTimeInstant.flatMap { end =>
           val status = exit match {
             case ExitCase.Succeeded => SpanStatus.Ok
-            case ExitCase.Errored(e) => SpanStatus.Internal(e.getMessage)
+            case ExitCase.Errored(e) => SpanStatus.Internal(Option(e.getMessage).getOrElse(e.toString()))
             case ExitCase.Canceled => SpanStatus.Cancelled
           }
 

--- a/modules/meta/src/main/scala/io/janstenpickle/trace4cats/meta/MetaTraceUtil.scala
+++ b/modules/meta/src/main/scala/io/janstenpickle/trace4cats/meta/MetaTraceUtil.scala
@@ -34,7 +34,7 @@ object MetaTraceUtil {
         Clock[F].realTimeInstant.flatMap { end =>
           val status = exit match {
             case ExitCase.Succeeded => SpanStatus.Ok
-            case ExitCase.Errored(e) => SpanStatus.Internal(Option(e.getMessage).getOrElse(e.toString()))
+            case ExitCase.Errored(e) => SpanStatus.Internal(Option(e.getMessage).getOrElse(e.toString))
             case ExitCase.Canceled => SpanStatus.Cancelled
           }
 


### PR DESCRIPTION
Default to `toString()` when `getMessage()` returns `null`.