### PR TITLE
Add helpers to construct a `Trace` backed by a `Ref`

### DIFF
--- a/modules/base-laws/src/test/scala/io/janstenpickle/trace4cats/base/context/laws/LiftTests.scala
+++ b/modules/base-laws/src/test/scala/io/janstenpickle/trace4cats/base/context/laws/LiftTests.scala
@@ -1,0 +1,7 @@
+package io.janstenpickle.trace4cats.base.context.laws
+
+import io.janstenpickle.trace4cats.base.context.laws.discipline
+
+class LiftTests extends BaseSuite {
+  checkAll("Lift[Option, Option]", discipline.LiftTests[Option, Option].lift[String, Int])
+}

--- a/modules/base-laws/src/test/scala/io/janstenpickle/trace4cats/base/context/laws/UnliftTests.scala
+++ b/modules/base-laws/src/test/scala/io/janstenpickle/trace4cats/base/context/laws/UnliftTests.scala
@@ -1,0 +1,12 @@
+package io.janstenpickle.trace4cats.base.context.laws
+
+import cats.~>
+import io.janstenpickle.trace4cats.base.context.laws.discipline
+import org.scalacheck.Cogen
+
+class UnliftTests extends BaseSuite {
+  implicit val cogenOption2Option: Cogen[Option ~> Option] =
+    Cogen(_ => 0L)
+
+  checkAll("Unlift[Option, Option]", discipline.UnliftTests[Option, Option].unlift[String, Int])
+}

--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Lift.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Lift.scala
@@ -20,4 +20,11 @@ trait Lift[Low[_], F[_]] extends ContextRoot { self =>
 
 object Lift {
   def apply[Low[_], F[_]](implicit ev: Lift[Low, F]): Lift[Low, F] = ev
+
+  trait IdLift[F[_]] extends Lift[F, F] {
+    def Low = F
+    def lift[A](fa: F[A]): F[A] = fa
+  }
+
+  implicit def idLift[F[_]](implicit M: Monad[F]): Lift[F, F] = new IdLift[F] { val F = M }
 }

--- a/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Unlift.scala
+++ b/modules/base/src/main/scala/io/janstenpickle/trace4cats/base/context/Unlift.scala
@@ -1,6 +1,7 @@
 package io.janstenpickle.trace4cats.base.context
 
 import cats.{~>, Monad}
+import cats.arrow.FunctionK
 
 trait Unlift[Low[_], F[_]] extends Lift[Low, F] { self =>
   def askUnlift: F[F ~> Low]
@@ -17,4 +18,10 @@ trait Unlift[Low[_], F[_]] extends Lift[Low, F] { self =>
 
 object Unlift {
   def apply[Low[_], F[_]](implicit ev: Unlift[Low, F]): Unlift[Low, F] = ev
+
+  trait IdUnlift[F[_]] extends Lift.IdLift[F] with Unlift[F, F] {
+    def askUnlift: F[F ~> F] = F.pure(FunctionK.id[F])
+  }
+
+  implicit def idUnlift[F[_]](implicit M: Monad[F]): Unlift[F, F] = new IdUnlift[F] { val F = M }
 }


### PR DESCRIPTION
Given a `Ref[F, Span[F]]` we can product an instance of `Local[F, Span[F]]`, which can be used to provide an implementation of `Trace[F]` via `Trace.localSpanInstance[F, F]`. This also adds supporting instances of `Lift[F, F]` and `Unlift[F, F]`.

This was inspired by [natchez's `Trace.ioTrace` method](https://github.com/tpolecat/natchez/blob/058f32553febb6b24403e765f86cbbaf3b28b08c/modules/core/shared/src/main/scala/Trace.scala#L46-L71). I was planning to add equivalents for constructing a `Trace[IO]` from an `IOLocal[Span[IO]]`, but `cats-effect` isn't currently available in the `inject` module. I think there are two approaches I could take to get it working, would you be okay with either?

1. Add `cats-effect` as a dependency to `inject`
2. Define a new `cats-effect` module that depends on `inject` and contains these helper methods