### PR TITLE
Improve derivation for `TraceId.Gen` & `SpanId.Gen`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val model =
     .settings(
       name := "trace4cats-model",
       libraryDependencies ++= Seq(
-        Dependencies.catsEffectKernel,
+        Dependencies.catsEffectStd,
         Dependencies.commonsCodec,
         // Dependencies.kittens, // TODO re-add once compatible with Scala 3
         Dependencies.caseInsensitive

--- a/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanId.scala
+++ b/modules/model/src/main/scala/io/janstenpickle/trace4cats/model/SpanId.scala
@@ -1,11 +1,12 @@
 package io.janstenpickle.trace4cats.model
 
 import cats.effect.kernel.Sync
+import cats.effect.std.Random
+import cats.syntax.functor._
 import cats.syntax.show._
-import cats.{Eq, Show}
+import cats.{Eq, Functor, Show}
 import org.apache.commons.codec.binary.Hex
 
-import java.util.concurrent.ThreadLocalRandom
 import scala.util.Try
 
 case class SpanId private (value: Array[Byte]) extends AnyVal {
@@ -19,18 +20,24 @@ object SpanId {
     def gen: F[SpanId]
   }
 
-  object Gen {
+  object Gen extends GenInstances0 {
     def apply[F[_]](implicit ev: Gen[F]): Gen[F] = ev
 
     def from[F[_]](f: F[SpanId]): Gen[F] = new Gen[F] {
       def gen: F[SpanId] = f
     }
+  }
 
-    implicit def threadLocalRandomSpanId[F[_]: Sync]: Gen[F] = Gen.from(Sync[F].delay {
-      val array = Array.fill[Byte](size)(0)
-      ThreadLocalRandom.current.nextBytes(array)
-      SpanId.unsafe(array)
-    })
+  trait GenInstances0 extends GenInstances1 {
+    implicit def fromRandomSpanIdGen[F[_]: Functor: Random]: Gen[F] =
+      Gen.from(Random[F].nextBytes(size).map(SpanId.unsafe))
+  }
+
+  trait GenInstances1 { this: GenInstances0 =>
+    implicit def threadLocalRandomSpanIdGen[F[_]: Sync]: Gen[F] = {
+      implicit val rnd: Random[F] = Random.javaUtilConcurrentThreadLocalRandom[F]
+      fromRandomSpanIdGen[F]
+    }
   }
 
   def gen[F[_]: Gen]: F[SpanId] = Gen[F].gen

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,6 @@ object Dependencies {
 
   lazy val caseInsensitive = "org.typelevel"           %% "case-insensitive"        % Versions.caseInsensitive
   lazy val cats = "org.typelevel"                      %% "cats-core"               % Versions.cats
-  lazy val catsEffectKernel = "org.typelevel"          %% "cats-effect-kernel"      % Versions.catsEffect
   lazy val catsEffectStd = "org.typelevel"             %% "cats-effect-std"         % Versions.catsEffect
   lazy val catsEffect = "org.typelevel"                %% "cats-effect"             % Versions.catsEffect
   lazy val commonsCodec = "commons-codec"               % "commons-codec"           % Versions.commonsCodec


### PR DESCRIPTION
I thought about @ybasket's https://github.com/trace4cats/trace4cats/pull/732#discussion_r850222888 and decided to make the derivation of `TraceId.Gen`/`SpanId.Gen` more flexible.

Now an end user can:
1. either use the default generators based on `ThreadLocalRandom`
2. or provide a different RNG instance <- _this is new_
3. or provide a fully custom generators