### PR TITLE
Add `Trace.WithContext`

### DIFF
--- a/modules/inject-io/src/main/scala/io/janstenpickle/trace4cats/inject/io/IOLocalTraceInstances.scala
+++ b/modules/inject-io/src/main/scala/io/janstenpickle/trace4cats/inject/io/IOLocalTraceInstances.scala
@@ -9,8 +9,8 @@ import io.janstenpickle.trace4cats.inject.Trace
 trait IOLocalTraceInstances {
 
   /** Construct a `Trace[IO]` instance backed by the given `IOLocal[Ctx]`. */
-  def ioLocalTrace[Ctx](rootCtx: IOLocal[Ctx])(implicit lens: Lens[Ctx, Span[IO]]): Trace[IO] = {
+  def ioLocalTrace[Ctx](rootCtx: IOLocal[Ctx])(implicit lens: Lens[Ctx, Span[IO]]): Trace.WithContext[IO] = {
     implicit val local: Local[IO, Span[IO]] = ioLocalProvide(rootCtx).focus(lens)
-    Trace[IO]
+    Trace.WithContext[IO]
   }
 }

--- a/modules/inject/src/main/scala/io/janstenpickle/trace4cats/inject/Trace.scala
+++ b/modules/inject/src/main/scala/io/janstenpickle/trace4cats/inject/Trace.scala
@@ -12,7 +12,7 @@ import cats.syntax.option._
 import cats.syntax.show._
 import cats.{Applicative, Functor}
 import io.janstenpickle.trace4cats.base.context.{Lift, Local}
-import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind, SpanStatus, TraceHeaders}
+import io.janstenpickle.trace4cats.model.{AttributeValue, SpanContext, SpanKind, SpanStatus, TraceHeaders}
 import io.janstenpickle.trace4cats.{ErrorHandler, Span, ToHeaders}
 
 /** A tracing effect, which always has a current span. */
@@ -43,6 +43,34 @@ trait Trace[F[_]] {
 }
 
 object Trace extends TraceInstancesLowPriority {
+  trait WithContext[F[_]] extends Trace[F] {
+    def context: F[SpanContext]
+  }
+  object WithContext {
+    def apply[F[_]](implicit ev: WithContext[F]): ev.type = ev
+
+    implicit def eitherTWithContext[F[_]: Functor, A](implicit trace: WithContext[F]): WithContext[EitherT[F, A, *]] =
+      new WithContext[EitherT[F, A, *]] {
+        override def put(key: String, value: AttributeValue): EitherT[F, A, Unit] = EitherT.liftF(trace.put(key, value))
+
+        override def putAll(fields: (String, AttributeValue)*): EitherT[F, A, Unit] =
+          EitherT.liftF(trace.putAll(fields: _*))
+
+        override def span[B](name: String, kind: SpanKind, errorHandler: ErrorHandler)(
+          fa: EitherT[F, A, B]
+        ): EitherT[F, A, B] = EitherT(trace.span(name, kind, errorHandler)(fa.value))
+
+        override def headers(toHeaders: ToHeaders): EitherT[F, A, TraceHeaders] =
+          EitherT.liftF(trace.headers(toHeaders))
+
+        override def setStatus(status: SpanStatus): EitherT[F, A, Unit] =
+          EitherT.liftF(trace.setStatus(status))
+
+        override def traceId: EitherT[F, A, Option[String]] = EitherT.liftF(trace.traceId)
+
+        override def context: EitherT[F, A, SpanContext] = EitherT.liftF(trace.context)
+      }
+  }
 
   def apply[F[_]](implicit ev: Trace[F]): ev.type = ev
 
@@ -51,8 +79,8 @@ object Trace extends TraceInstancesLowPriority {
     /** A no-op `Trace` implementation is freely available for any applicative effect. This lets us add a `Trace`
       * constraint to most existing code without demanding anything new from the concrete effect type.
       */
-    implicit def noop[F[_]: Applicative]: Trace[F] =
-      new Trace[F] {
+    implicit def noop[F[_]: Applicative]: WithContext[F] =
+      new WithContext[F] {
         final val void = ().pure[F]
         override val headers: F[TraceHeaders] = TraceHeaders.empty.pure[F]
         override def headers(toHeaders: ToHeaders): F[TraceHeaders] = TraceHeaders.empty.pure[F]
@@ -65,6 +93,7 @@ object Trace extends TraceInstancesLowPriority {
         override def span[A](name: String, kind: SpanKind, errorHandler: ErrorHandler)(fa: F[A]): F[A] = fa
         override def setStatus(status: SpanStatus): F[Unit] = void
         override def traceId: F[Option[String]] = Option.empty[String].pure[F]
+        override def context: F[SpanContext] = SpanContext.invalid.pure[F]
       }
 
   }
@@ -78,7 +107,7 @@ object Trace extends TraceInstancesLowPriority {
   /** A trace instance for `Kleisli[F, Span[F], *]`, which is the mechanism we use to introduce context into our
     * computations. We can also "lensMap" out to `Kleisli[F, E, *]` given a lens from `E` to `Span[F]`.
     */
-  class KleisliTrace[F[_]: MonadCancelThrow] extends Trace[Kleisli[F, Span[F], *]] {
+  class KleisliTrace[F[_]: MonadCancelThrow] extends WithContext[Kleisli[F, Span[F], *]] {
 
     override def headers(toHeaders: ToHeaders): Kleisli[F, Span[F], TraceHeaders] =
       Kleisli { span =>
@@ -100,8 +129,10 @@ object Trace extends TraceInstancesLowPriority {
 
     override def traceId: Kleisli[F, Span[F], Option[String]] = Kleisli(span => span.context.traceId.show.some.pure[F])
 
-    def lens[E](f: E => Span[F], g: (E, Span[F]) => E): Trace[Kleisli[F, E, *]] =
-      new Trace[Kleisli[F, E, *]] {
+    override def context: Kleisli[F, Span[F], SpanContext] = Kleisli(span => span.context.pure[F])
+
+    def lens[E](f: E => Span[F], g: (E, Span[F]) => E): WithContext[Kleisli[F, E, *]] =
+      new WithContext[Kleisli[F, E, *]] {
         override def put(key: String, value: AttributeValue): Kleisli[F, E, Unit] =
           Kleisli(e => f(e).put(key, value))
 
@@ -120,6 +151,8 @@ object Trace extends TraceInstancesLowPriority {
           Kleisli(e => f(e).setStatus(status))
 
         override def traceId: Kleisli[F, E, Option[String]] = Kleisli(e => f(e).context.traceId.show.some.pure[F])
+
+        override def context: Kleisli[F, E, SpanContext] = Kleisli(e => f(e).context.pure[F])
       }
 
   }
@@ -151,7 +184,7 @@ trait TraceInstancesLowPriority {
     L: Lift[F, G],
     F: MonadCancelThrow[F],
     G: MonadCancelThrow[G]
-  ): Trace[G] = new Trace[G] {
+  ): Trace.WithContext[G] = new Trace.WithContext[G] {
     def put(key: String, value: AttributeValue): G[Unit] = C.accessF(span => L.lift(span.put(key, value)))
     def putAll(fields: (String, AttributeValue)*): G[Unit] = C.accessF(span => L.lift(span.putAll(fields: _*)))
     def span[A](name: String, kind: SpanKind, errorHandler: ErrorHandler)(fa: G[A]): G[A] =
@@ -160,5 +193,6 @@ trait TraceInstancesLowPriority {
       C.access(span => toHeaders.fromContext(span.context))
     def setStatus(status: SpanStatus): G[Unit] = C.accessF(span => L.lift(span.setStatus(status)))
     def traceId: G[Option[String]] = C.access(_.context.traceId.show.some)
+    def context: G[SpanContext] = C.access(_.context)
   }
 }

--- a/modules/inject/src/test/scala/io/janstenpickle/trace4cats/inject/EitherTTraceInstanceSummonTest.scala
+++ b/modules/inject/src/test/scala/io/janstenpickle/trace4cats/inject/EitherTTraceInstanceSummonTest.scala
@@ -1,0 +1,11 @@
+package io.janstenpickle.trace4cats.inject
+
+import cats.data.{EitherT, Kleisli}
+import cats.effect.IO
+import io.janstenpickle.trace4cats.Span
+
+object EitherTTraceInstanceSummonTest {
+  type F[x] = Kleisli[IO, Span[IO], x]
+  implicitly[Trace[EitherT[F, Unit, *]]]
+  implicitly[Trace.WithContext[EitherT[F, Unit, *]]]
+}

--- a/modules/inject/src/test/scala/io/janstenpickle/trace4cats/inject/KleisliTraceInstanceSummonTest.scala
+++ b/modules/inject/src/test/scala/io/janstenpickle/trace4cats/inject/KleisliTraceInstanceSummonTest.scala
@@ -8,8 +8,10 @@ import io.janstenpickle.trace4cats.base.context.Local
 object KleisliTraceInstanceSummonTest {
   type F[x] = Kleisli[IO, Span[IO], x]
   implicitly[Trace[F]]
+  implicitly[Trace.WithContext[F]]
 
   type G[x] = Kleisli[IO, Env[IO], x]
   implicit val gHasLocalSpan: Local[G, Span[IO]] = Local[G, Env[IO]].focus(Env.span)
   implicitly[Trace[G]]
+  implicitly[Trace.WithContext[G]]
 }


### PR DESCRIPTION
Adds the ability to obtain a span context from a `Trace` typeclass. This has been added as a more powerful typeclass so compatibility with Natchez can be preserved.

An obivious question may be, why not just use `Ask` here? Obtaining the context this way means that we don't have to either pass another type parameter for `F` on `Span[F]` when using `Ask[G, Span[F]]` or making users manually provide an `Ask[G, SpanContext]` instance using `zoom`.