### PR TITLE
Fix DischargeSpan's parent of child

### DIFF
--- a/modules/kernel/src/main/scala/io/janstenpickle/trace4cats/Span.scala
+++ b/modules/kernel/src/main/scala/io/janstenpickle/trace4cats/Span.scala
@@ -111,9 +111,9 @@ case class DischargeSpan[F[_]: Monad: Clock: Ref.Make: TraceId.Gen: SpanId.Gen] 
   def addLink(link: Link): F[Unit] = Applicative[F].unit
   def addLinks(links: NonEmptyList[Link]): F[Unit] = Applicative[F].unit
   def child(name: String, kind: SpanKind): Resource[F, Span[F]] =
-    Resource.eval(SpanContext.root[F]).flatMap(Span.child(name, _, kind, sampler, completer))
+    Span.root(name, kind, sampler, completer)
   def child(name: String, kind: SpanKind, errorHandler: ErrorHandler): Resource[F, Span[F]] =
-    Resource.eval(SpanContext.root[F]).flatMap(Span.child(name, _, kind, sampler, completer, errorHandler))
+    Span.root(name, kind, sampler, completer, errorHandler)
 }
 
 object Span {


### PR DESCRIPTION
Use Span.root to avoid setting a parent for child spans created from DischargeSpan. As DischargeSpan's children are semantically root spans, they should not reference a parent span or tracing backends will report warnings about missing parents.

Old implementation:
<img width="1474" alt="Screenshot 2022-05-07 at 14 30 06" src="https://user-images.githubusercontent.com/2632023/167254646-0cebc512-ef25-47ab-a93c-39d4682a6d44.png">

With this PR:
<img width="1475" alt="Screenshot 2022-05-07 at 14 30 20" src="https://user-images.githubusercontent.com/2632023/167254650-7d97147e-1d75-4c09-bb23-78e57ebb09db.png">
