### PR TITLE
Span params case class

### DIFF
--- a/modules/core/src/main/scala/trace4cats/EntryPoint.scala
+++ b/modules/core/src/main/scala/trace4cats/EntryPoint.scala
@@ -15,27 +15,27 @@ import cats.{~>, Applicative, Monad}
 trait EntryPoint[F[_]] {
 
   /** Resource that creates a new root span in a new trace. */
-  def root(name: SpanName): Resource[F, Span[F]] = root(name, SpanKind.Internal)
-  def root(name: SpanName, kind: SpanKind): Resource[F, Span[F]] = root(name, kind, ErrorHandler.empty)
-  def root(name: SpanName, kind: SpanKind, errorHandler: ErrorHandler): Resource[F, Span[F]]
+  def root(name: String): Resource[F, Span[F]] = root(name, SpanKind.Internal)
+  def root(name: String, kind: SpanKind): Resource[F, Span[F]] = root(name, kind, ErrorHandler.empty)
+  def root(name: String, kind: SpanKind, errorHandler: ErrorHandler): Resource[F, Span[F]]
 
   /** Resource that attempts to creates a new child span but falls back to a new root span as with `root` if the headers
     * do not contain the required values. In other words, we continue the existing span if we can, otherwise we start a
     * new one.
     */
-  def continueOrElseRoot(name: SpanName, headers: TraceHeaders): Resource[F, Span[F]] =
+  def continueOrElseRoot(name: String, headers: TraceHeaders): Resource[F, Span[F]] =
     continueOrElseRoot(name, SpanKind.Server, headers)
-  def continueOrElseRoot(name: SpanName, kind: SpanKind, headers: TraceHeaders): Resource[F, Span[F]] =
+  def continueOrElseRoot(name: String, kind: SpanKind, headers: TraceHeaders): Resource[F, Span[F]] =
     continueOrElseRoot(name, kind, headers, ErrorHandler.empty)
   def continueOrElseRoot(
-    name: SpanName,
+    name: String,
     kind: SpanKind,
     headers: TraceHeaders,
     errorHandler: ErrorHandler
   ): Resource[F, Span[F]]
 
   def toKleisli: ResourceKleisli[F, SpanParams, Span[F]] =
-    Kleisli { case (name, kind, headers, errorHandler) =>
+    Kleisli { case SpanParams(name, kind, headers, errorHandler) =>
       continueOrElseRoot(name, kind, headers, errorHandler)
     }
 
@@ -64,11 +64,11 @@ object EntryPoint {
     toHeaders: ToHeaders = ToHeaders.standard
   ): EntryPoint[F] =
     new EntryPoint[F] {
-      override def root(name: SpanName, kind: SpanKind, errorHandler: ErrorHandler): Resource[F, Span[F]] =
+      override def root(name: String, kind: SpanKind, errorHandler: ErrorHandler): Resource[F, Span[F]] =
         Span.root[F](name, kind, sampler, completer, errorHandler)
 
       override def continueOrElseRoot(
-        name: SpanName,
+        name: String,
         kind: SpanKind,
         headers: TraceHeaders,
         errorHandler: ErrorHandler
@@ -80,9 +80,9 @@ object EntryPoint {
 
   def noop[F[_]: Applicative]: EntryPoint[F] =
     new EntryPoint[F] {
-      override def root(name: SpanName, kind: SpanKind, errorHandler: ErrorHandler): Resource[F, Span[F]] = Span.noop[F]
+      override def root(name: String, kind: SpanKind, errorHandler: ErrorHandler): Resource[F, Span[F]] = Span.noop[F]
       override def continueOrElseRoot(
-        name: SpanName,
+        name: String,
         kind: SpanKind,
         headers: TraceHeaders,
         errorHandler: ErrorHandler
@@ -92,10 +92,10 @@ object EntryPoint {
 
   private def mapK[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](fk: F ~> G)(ep: EntryPoint[F]): EntryPoint[G] =
     new EntryPoint[G] {
-      def root(name: SpanName, kind: SpanKind, errorHandler: ErrorHandler): Resource[G, Span[G]] =
+      def root(name: String, kind: SpanKind, errorHandler: ErrorHandler): Resource[G, Span[G]] =
         ep.root(name, kind, errorHandler).map(_.mapK(fk)).mapK(fk)
       def continueOrElseRoot(
-        name: SpanName,
+        name: String,
         kind: SpanKind,
         headers: TraceHeaders,
         errorHandler: ErrorHandler

--- a/modules/core/src/main/scala/trace4cats/package.scala
+++ b/modules/core/src/main/scala/trace4cats/package.scala
@@ -5,8 +5,9 @@ import trace4cats.{kernel => t4ckernel, model => t4cmodel}
 import scala.annotation.unchecked.uncheckedVariance
 
 package object trace4cats {
+  @deprecated("Use String instead", "0.14.0")
   type SpanName = String
-  type SpanParams = (SpanName, SpanKind, TraceHeaders, ErrorHandler)
+
   type ResourceKleisli[F[_], -In, +Out] = Kleisli[Resource[F, +*], In, Out @uncheckedVariance]
 
   // kernel aliases
@@ -60,6 +61,9 @@ package object trace4cats {
 
   type TraceHeaders = t4cmodel.TraceHeaders
   val TraceHeaders = t4cmodel.TraceHeaders
+
+  type SpanParams = t4cmodel.SpanParams
+  val SpanParams = t4cmodel.SpanParams
 
   type TraceId = t4cmodel.TraceId
   val TraceId = t4cmodel.TraceId

--- a/modules/core/src/main/scala/trace4cats/syntax/package.scala
+++ b/modules/core/src/main/scala/trace4cats/syntax/package.scala
@@ -2,7 +2,7 @@ package trace4cats
 
 package object syntax {
   final implicit class TraceOps[F[_], A](private val fa: F[A]) extends AnyVal {
-    def span(name: SpanName)(implicit T: Trace[F]): F[A] = T.span(name)(fa)
-    def span(name: SpanName, kind: SpanKind)(implicit T: Trace[F]): F[A] = T.span(name, kind)(fa)
+    def span(name: String)(implicit T: Trace[F]): F[A] = T.span(name)(fa)
+    def span(name: String, kind: SpanKind)(implicit T: Trace[F]): F[A] = T.span(name, kind)(fa)
   }
 }

--- a/modules/fs2/src/main/scala/trace4cats/fs2/syntax/Fs2StreamSyntax.scala
+++ b/modules/fs2/src/main/scala/trace4cats/fs2/syntax/Fs2StreamSyntax.scala
@@ -11,37 +11,37 @@ import trace4cats.context.Provide
 import trace4cats.fs2.{ContinuationSpan, TracedStream}
 import trace4cats.kernel.{ErrorHandler, Span, ToHeaders}
 import trace4cats.model.{AttributeValue, SpanKind, TraceHeaders}
-import trace4cats.{EntryPoint, ResourceKleisli, SpanName, SpanParams}
+import trace4cats.{EntryPoint, ResourceKleisli, SpanParams}
 
 trait Fs2StreamSyntax {
   implicit class InjectEntryPoint[F[_]: MonadCancelThrow, A](stream: Stream[F, A]) {
     def inject(ep: EntryPoint[F], name: String): TracedStream[F, A] =
       inject(ep, _ => name, SpanKind.Internal)
 
-    def trace(k: ResourceKleisli[F, SpanParams, Span[F]], name: SpanName): TracedStream[F, A] =
+    def trace(k: ResourceKleisli[F, SpanParams, Span[F]], name: String): TracedStream[F, A] =
       trace(k, _ => name, SpanKind.Internal)
 
     def inject(ep: EntryPoint[F], name: A => String): TracedStream[F, A] =
       inject(ep, name, SpanKind.Internal)
 
-    def trace(k: ResourceKleisli[F, SpanParams, Span[F]], name: A => SpanName): TracedStream[F, A] =
+    def trace(k: ResourceKleisli[F, SpanParams, Span[F]], name: A => String): TracedStream[F, A] =
       trace(k, name, SpanKind.Internal)
 
-    def inject(ep: EntryPoint[F], name: SpanName, kind: SpanKind): TracedStream[F, A] =
+    def inject(ep: EntryPoint[F], name: String, kind: SpanKind): TracedStream[F, A] =
       inject(ep, _ => name, kind)
 
-    def trace(k: ResourceKleisli[F, SpanParams, Span[F]], name: SpanName, kind: SpanKind): TracedStream[F, A] =
+    def trace(k: ResourceKleisli[F, SpanParams, Span[F]], name: String, kind: SpanKind): TracedStream[F, A] =
       trace(k, _ => name, kind)
 
-    def inject(ep: EntryPoint[F], name: A => SpanName, kind: SpanKind): TracedStream[F, A] =
+    def inject(ep: EntryPoint[F], name: A => String, kind: SpanKind): TracedStream[F, A] =
       trace(ep.toKleisli, name, kind)
 
-    def trace(k: ResourceKleisli[F, SpanParams, Span[F]], name: A => SpanName, kind: SpanKind): TracedStream[F, A] =
+    def trace(k: ResourceKleisli[F, SpanParams, Span[F]], name: A => String, kind: SpanKind): TracedStream[F, A] =
       trace(k, name, kind, ErrorHandler.empty)
 
     def trace(
       k: ResourceKleisli[F, SpanParams, Span[F]],
-      name: A => SpanName,
+      name: A => String,
       kind: SpanKind,
       errorHandler: ErrorHandler
     ): TracedStream[F, A] =
@@ -50,39 +50,37 @@ trait Fs2StreamSyntax {
     def injectContinue(ep: EntryPoint[F], name: String)(f: A => TraceHeaders): TracedStream[F, A] =
       injectContinue(ep, name, SpanKind.Internal)(f)
 
-    def traceContinue(k: ResourceKleisli[F, SpanParams, Span[F]], name: SpanName)(
+    def traceContinue(k: ResourceKleisli[F, SpanParams, Span[F]], name: String)(
       f: A => TraceHeaders
     ): TracedStream[F, A] =
       traceContinue(k, name, SpanKind.Internal)(f)
 
-    def injectContinue(ep: EntryPoint[F], name: SpanName, kind: SpanKind)(f: A => TraceHeaders): TracedStream[F, A] =
+    def injectContinue(ep: EntryPoint[F], name: String, kind: SpanKind)(f: A => TraceHeaders): TracedStream[F, A] =
       injectContinue(ep, _ => name, kind)(f)
 
-    def traceContinue(k: ResourceKleisli[F, SpanParams, Span[F]], name: SpanName, kind: SpanKind)(
+    def traceContinue(k: ResourceKleisli[F, SpanParams, Span[F]], name: String, kind: SpanKind)(
       f: A => TraceHeaders
     ): TracedStream[F, A] =
       traceContinue(k, _ => name, kind)(f)
 
-    def injectContinue(ep: EntryPoint[F], name: A => SpanName)(f: A => TraceHeaders): TracedStream[F, A] =
+    def injectContinue(ep: EntryPoint[F], name: A => String)(f: A => TraceHeaders): TracedStream[F, A] =
       injectContinue(ep, name, SpanKind.Internal)(f)
 
-    def traceContinue(k: ResourceKleisli[F, SpanParams, Span[F]], name: A => SpanName)(
+    def traceContinue(k: ResourceKleisli[F, SpanParams, Span[F]], name: A => String)(
       f: A => TraceHeaders
     ): TracedStream[F, A] =
       traceContinue(k, name, SpanKind.Internal)(f)
 
-    def injectContinue(ep: EntryPoint[F], name: A => SpanName, kind: SpanKind)(
-      f: A => TraceHeaders
-    ): TracedStream[F, A] =
+    def injectContinue(ep: EntryPoint[F], name: A => String, kind: SpanKind)(f: A => TraceHeaders): TracedStream[F, A] =
       traceContinue(ep.toKleisli, name, kind)(f)
 
-    def traceContinue(k: ResourceKleisli[F, SpanParams, Span[F]], name: A => SpanName, kind: SpanKind)(
+    def traceContinue(k: ResourceKleisli[F, SpanParams, Span[F]], name: A => String, kind: SpanKind)(
       f: A => TraceHeaders
     ): TracedStream[F, A] = traceContinue(k, name, kind, ErrorHandler.empty)(f)
 
     def traceContinue(
       k: ResourceKleisli[F, SpanParams, Span[F]],
-      name: A => SpanName,
+      name: A => String,
       kind: SpanKind,
       errorHandler: ErrorHandler
     )(f: A => TraceHeaders): TracedStream[F, A] =

--- a/modules/kernel/src/main/scala/trace4cats/model/SpanParams.scala
+++ b/modules/kernel/src/main/scala/trace4cats/model/SpanParams.scala
@@ -1,0 +1,10 @@
+package trace4cats.model
+
+import trace4cats.kernel.ErrorHandler
+
+case class SpanParams(spanName: String, spanKind: SpanKind, traceHeaders: TraceHeaders, errorHandler: ErrorHandler)
+
+object SpanParams {
+  implicit def fromTuple(t: (String, SpanKind, TraceHeaders, ErrorHandler)): SpanParams =
+    SpanParams(t._1, t._2, t._3, t._4)
+}


### PR DESCRIPTION
- Make span params a case class to make parameters in a `ResourceKleisli` more obvious
- Deprecate `SpanName` type alias in favour of `String`

Fixes #757 