### PR TITLE
Fix stream span exporter monoid

### DIFF
--- a/modules/core/src/main/scala/trace4cats/StreamSpanExporter.scala
+++ b/modules/core/src/main/scala/trace4cats/StreamSpanExporter.scala
@@ -25,8 +25,6 @@ object StreamSpanExporter {
 
       override def combine(x: StreamSpanExporter[F], y: StreamSpanExporter[F]): StreamSpanExporter[F] =
         new StreamSpanExporter[F] {
-          override def pipe: Pipe[F, CompletedSpan, Unit] = in => in.through(x.pipe).concurrently(in.through(y.pipe))
-
           override def exportBatch(batch: Batch[Chunk]): F[Unit] =
             Parallel.parMap2(x.exportBatch(batch), y.exportBatch(batch))((_, _) => ())
         }


### PR DESCRIPTION
The monoid instance for stream span exporter was losing data when
running two streams concurrently. This removes the override that
delegated to FS2 and simply relies on the `Parallel` instance,
which is much more reliable