### PR TITLE
Reinstate monoid instances

### DIFF
--- a/modules/core/src/main/scala/trace4cats/QueuedSpanExporter.scala
+++ b/modules/core/src/main/scala/trace4cats/QueuedSpanExporter.scala
@@ -7,6 +7,7 @@ import cats.effect.syntax.monadCancel._
 import cats.effect.syntax.spawn._
 import cats.effect.syntax.temporal._
 import cats.syntax.flatMap._
+import cats.syntax.foldable._
 import cats.syntax.functor._
 import cats.syntax.monad._
 import cats.syntax.parallel._
@@ -48,7 +49,7 @@ object QueuedSpanExporter {
         }
       }
       .parTraverse(buffer)
-      .map(StreamSpanExporter.combined[F])
+      .map(_.combineAll)
   }
 
 }

--- a/modules/core/src/main/scala/trace4cats/StreamSpanExporter.scala
+++ b/modules/core/src/main/scala/trace4cats/StreamSpanExporter.scala
@@ -4,6 +4,8 @@ import cats.effect.kernel.Concurrent
 import cats.syntax.functor._
 import cats.{Applicative, Monoid, Parallel}
 import fs2.{Chunk, Pipe}
+import trace4cats.model.Batch
+import cats.syntax.parallel._
 
 trait StreamSpanExporter[F[_]] extends SpanExporter[F, Chunk] {
   def pipe: Pipe[F, CompletedSpan, Unit] = _.chunks.evalMap(chunk => exportBatch(Batch(chunk)))
@@ -27,6 +29,15 @@ object StreamSpanExporter {
         new StreamSpanExporter[F] {
           override def exportBatch(batch: Batch[Chunk]): F[Unit] =
             Parallel.parMap2(x.exportBatch(batch), y.exportBatch(batch))((_, _) => ())
+        }
+
+      override def combineAllOption(as: IterableOnce[StreamSpanExporter[F]]): Option[StreamSpanExporter[F]] =
+        if (as.iterator.isEmpty) None
+        else Some(combineAll(as))
+
+      override def combineAll(as: IterableOnce[StreamSpanExporter[F]]): StreamSpanExporter[F] =
+        new StreamSpanExporter[F] {
+          override def exportBatch(batch: Batch[Chunk]): F[Unit] = as.iterator.toList.parTraverse_(_.exportBatch(batch))
         }
     }
 }

--- a/modules/kernel-tests/src/test/scala/trace4cats/kernel/SpanCompleterSpec.scala
+++ b/modules/kernel-tests/src/test/scala/trace4cats/kernel/SpanCompleterSpec.scala
@@ -1,0 +1,34 @@
+package trace4cats.kernel
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.kernel.laws.discipline.MonoidTests
+import cats.{Applicative, Eq, Id}
+import trace4cats.model.CompletedSpan
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
+
+class SpanCompleterSpec extends AnyFunSuite with ScalaCheckDrivenPropertyChecks with FunSuiteDiscipline {
+  val completedSpan: CompletedSpan.Builder = null
+
+  def spanCompleterArb[F[_]: Applicative]: Arbitrary[SpanCompleter[F]] =
+    Arbitrary(Gen.const(SpanCompleter.empty[F]))
+  implicit val idSpanCompleter: Arbitrary[SpanCompleter[Id]] = spanCompleterArb
+  implicit val ioSpanCompleter: Arbitrary[SpanCompleter[IO]] = spanCompleterArb
+
+  implicit val idSpanCompleterEq: Eq[SpanCompleter[Id]] = new Eq[SpanCompleter[Id]] {
+    override def eqv(x: SpanCompleter[Id], y: SpanCompleter[Id]): Boolean =
+      x.complete(completedSpan) === y.complete(completedSpan)
+  }
+
+  implicit val ioSpanCompleterEq: Eq[SpanCompleter[IO]] = new Eq[SpanCompleter[IO]] {
+    override def eqv(x: SpanCompleter[IO], y: SpanCompleter[IO]): Boolean =
+      x.complete(completedSpan).unsafeRunSync() === y.complete(completedSpan).unsafeRunSync()
+  }
+
+  checkAll("SpanCompleter Monoid non-parallel", MonoidTests[SpanCompleter[Id]].monoid)
+  checkAll("SpanCompleter Monoid parallel", MonoidTests[SpanCompleter[IO]].monoid)
+
+}

--- a/modules/kernel-tests/src/test/scala/trace4cats/kernel/SpanExporterSpec.scala
+++ b/modules/kernel-tests/src/test/scala/trace4cats/kernel/SpanExporterSpec.scala
@@ -1,0 +1,34 @@
+package trace4cats.kernel
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.kernel.laws.discipline.MonoidTests
+import cats.{Applicative, Eq, Id}
+import trace4cats.model.Batch
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
+
+class SpanExporterSpec extends AnyFunSuite with ScalaCheckDrivenPropertyChecks with FunSuiteDiscipline {
+  val batch: Batch[List] = Batch[List](List.empty)
+
+  def spanExporterArb[F[_]: Applicative]: Arbitrary[SpanExporter[F, List]] =
+    Arbitrary(Gen.const(SpanExporter.empty[F, List]))
+  implicit val idSpanCompleter: Arbitrary[SpanExporter[Id, List]] = spanExporterArb
+  implicit val ioSpanCompleter: Arbitrary[SpanExporter[IO, List]] = spanExporterArb
+
+  implicit val idSpanCompleterEq: Eq[SpanExporter[Id, List]] = new Eq[SpanExporter[Id, List]] {
+    override def eqv(x: SpanExporter[Id, List], y: SpanExporter[Id, List]): Boolean =
+      x.exportBatch(batch) === y.exportBatch(batch)
+  }
+
+  implicit val ioSpanCompleterEq: Eq[SpanExporter[IO, List]] = new Eq[SpanExporter[IO, List]] {
+    override def eqv(x: SpanExporter[IO, List], y: SpanExporter[IO, List]): Boolean =
+      x.exportBatch(batch).unsafeRunSync() === y.exportBatch(batch).unsafeRunSync()
+  }
+
+  checkAll("SpanExporter Monoid non-parallel", MonoidTests[SpanExporter[Id, List]].monoid)
+  checkAll("SpanExporter Monoid parallel", MonoidTests[SpanExporter[IO, List]].monoid)
+
+}

--- a/modules/kernel/src/main/scala/trace4cats/kernel/SpanCompleter.scala
+++ b/modules/kernel/src/main/scala/trace4cats/kernel/SpanCompleter.scala
@@ -1,7 +1,7 @@
 package trace4cats.kernel
 
-import cats.syntax.parallel._
-import cats.{Applicative, Parallel}
+import cats.kernel.Monoid
+import cats.{Applicative, Apply, Parallel}
 import trace4cats.model.CompletedSpan
 import trace4cats.model.CompletedSpan.Builder
 
@@ -9,13 +9,33 @@ trait SpanCompleter[F[_]] {
   def complete(span: CompletedSpan.Builder): F[Unit]
 }
 
-object SpanCompleter {
+object SpanCompleter extends LowPrioritySpanCompleterInstances {
+  implicit def spanCompleterMonoidFromParallel[F[_]: Applicative: Parallel]: Monoid[SpanCompleter[F]] =
+    new Monoid[SpanCompleter[F]] {
+      override def combine(x: SpanCompleter[F], y: SpanCompleter[F]): SpanCompleter[F] =
+        new SpanCompleter[F] {
+          override def complete(span: CompletedSpan.Builder): F[Unit] =
+            Parallel.parMap2(x.complete(span), y.complete(span))((_, _) => ())
+        }
+
+      override def empty: SpanCompleter[F] = SpanCompleter.empty[F]
+    }
+}
+
+trait LowPrioritySpanCompleterInstances {
+  implicit def spanCompleterMonoidFromApply[F[_]: Applicative]: Monoid[SpanCompleter[F]] =
+    new Monoid[SpanCompleter[F]] {
+      override def combine(x: SpanCompleter[F], y: SpanCompleter[F]): SpanCompleter[F] =
+        new SpanCompleter[F] {
+          override def complete(span: Builder): F[Unit] =
+            Apply[F].map2(x.complete(span), y.complete(span))((_, _) => ())
+        }
+
+      override def empty: SpanCompleter[F] = SpanCompleter.empty[F]
+    }
+
   def empty[F[_]: Applicative]: SpanCompleter[F] =
     new SpanCompleter[F] {
       override def complete(span: CompletedSpan.Builder): F[Unit] = Applicative[F].unit
     }
-
-  def combined[F[_]: Parallel](completers: List[SpanCompleter[F]]): SpanCompleter[F] = new SpanCompleter[F] {
-    override def complete(span: Builder): F[Unit] = completers.parTraverse_(_.complete(span))
-  }
 }

--- a/modules/kernel/src/main/scala/trace4cats/kernel/SpanExporter.scala
+++ b/modules/kernel/src/main/scala/trace4cats/kernel/SpanExporter.scala
@@ -1,14 +1,14 @@
 package trace4cats.kernel
 
-import cats.syntax.parallel._
-import cats.{Applicative, ApplicativeError, Parallel}
+import cats.kernel.Monoid
+import cats.{Applicative, ApplicativeError, Apply, Parallel}
 import trace4cats.model.Batch
 
 trait SpanExporter[F[_], G[_]] {
   def exportBatch(batch: Batch[G]): F[Unit]
 }
 
-object SpanExporter {
+object SpanExporter extends LowPrioritySpanExporterInstances {
   def handleErrors[F[_], G[_], E](
     exporter: SpanExporter[F, G]
   )(pf: PartialFunction[E, F[Unit]])(implicit F: ApplicativeError[F, E]): SpanExporter[F, G] =
@@ -16,12 +16,32 @@ object SpanExporter {
       override def exportBatch(batch: Batch[G]): F[Unit] = F.recoverWith(exporter.exportBatch(batch))(pf)
     }
 
+  implicit def spanExporterMonoidFromParallel[F[_]: Applicative: Parallel, G[_]]: Monoid[SpanExporter[F, G]] =
+    new Monoid[SpanExporter[F, G]] {
+      override def combine(x: SpanExporter[F, G], y: SpanExporter[F, G]): SpanExporter[F, G] =
+        new SpanExporter[F, G] {
+          override def exportBatch(batch: Batch[G]): F[Unit] =
+            Parallel.parMap2(x.exportBatch(batch), y.exportBatch(batch))((_, _) => ())
+        }
+
+      override def empty: SpanExporter[F, G] = SpanExporter.empty[F, G]
+    }
+}
+
+trait LowPrioritySpanExporterInstances {
+  implicit def spanExporterMonoidFromApply[F[_]: Applicative, G[_]]: Monoid[SpanExporter[F, G]] =
+    new Monoid[SpanExporter[F, G]] {
+      override def combine(x: SpanExporter[F, G], y: SpanExporter[F, G]): SpanExporter[F, G] =
+        new SpanExporter[F, G] {
+          override def exportBatch(batch: Batch[G]): F[Unit] =
+            Apply[F].map2(x.exportBatch(batch), y.exportBatch(batch))((_, _) => ())
+        }
+
+      override def empty: SpanExporter[F, G] = SpanExporter.empty[F, G]
+    }
+
   def empty[F[_]: Applicative, G[_]]: SpanExporter[F, G] =
     new SpanExporter[F, G] {
       override def exportBatch(batch: Batch[G]): F[Unit] = Applicative[F].unit
     }
-
-  def combined[F[_]: Parallel, G[_]](exporters: List[SpanExporter[F, G]]): SpanExporter[F, G] = new SpanExporter[F, G] {
-    override def exportBatch(batch: Batch[G]): F[Unit] = exporters.parTraverse_(_.exportBatch(batch))
-  }
 }


### PR DESCRIPTION
It turns out that an overloaded dependency was the cause of the problem, that mean I was still affected by #785. This reinstates the monoid instances and overrides the `combineAll` methods.