### PR TITLE
Rework span queued span completer

### DIFF
--- a/modules/core-tests/src/test/scala/trace4cats/QueuedSpanCompleterSpec.scala
+++ b/modules/core-tests/src/test/scala/trace4cats/QueuedSpanCompleterSpec.scala
@@ -19,7 +19,7 @@ class QueuedSpanCompleterSpec extends AnyFlatSpec with Matchers with TestInstanc
   behavior.of("QueuedSpanCompleter")
 
   def delayedExporter(ref: Ref[IO, Int]): SpanExporter[IO, Chunk] = new SpanExporter[IO, Chunk] {
-    def exportBatch(batch: Batch[Chunk]): IO[Unit] = IO.sleep(10.millis) >> ref.update(_ + batch.spans.size)
+    def exportBatch(batch: Batch[Chunk]): IO[Unit] = IO.sleep(20.millis) >> ref.update(_ + batch.spans.size)
   }
 
   def refExporter(ref: Ref[IO, Chunk[CompletedSpan]]): SpanExporter[IO, Chunk] = new SpanExporter[IO, Chunk] {
@@ -44,7 +44,7 @@ class QueuedSpanCompleterSpec extends AnyFlatSpec with Matchers with TestInstanc
     } yield res
 
     val result = test.unsafeRunSync()
-    result shouldBe (<(10.millis))
+    result shouldBe (<(20.millis))
   }
 
   it should "export all spans on shutdown" in forAll { (builder: CompletedSpan.Builder) =>

--- a/modules/core-tests/src/test/scala/trace4cats/QueuedSpanCompleterSpec.scala
+++ b/modules/core-tests/src/test/scala/trace4cats/QueuedSpanCompleterSpec.scala
@@ -56,12 +56,12 @@ class QueuedSpanCompleterSpec extends AnyFlatSpec with Matchers with TestInstanc
         exporter,
         CompleterConfig(bufferSize = 50000, batchSize = 200)
       ).use { completer =>
-        List.fill(10000)(completer.complete(builder)).sequence
+        List.fill(10001)(completer.complete(builder)).sequence
       }
       res <- ref.get
     } yield res
 
     val result = test.unsafeRunSync()
-    result.size shouldBe 10000
+    result.size shouldBe 10001
   }
 }

--- a/modules/core-tests/src/test/scala/trace4cats/QueuedSpanCompleterSpec.scala
+++ b/modules/core-tests/src/test/scala/trace4cats/QueuedSpanCompleterSpec.scala
@@ -1,0 +1,74 @@
+package trace4cats
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+import cats.effect.std.Random
+import cats.effect.testkit.TestInstances
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+import fs2.Chunk
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import trace4cats.test.ArbitraryInstances._
+
+import scala.concurrent.duration._
+
+class QueuedSpanCompleterSpec extends AnyFlatSpec with Matchers with TestInstances with ScalaCheckDrivenPropertyChecks {
+  behavior.of("QueuedSpanCompleter")
+
+  def delayedExporter(ref: Ref[IO, Int]): SpanExporter[IO, Chunk] = new SpanExporter[IO, Chunk] {
+    def exportBatch(batch: Batch[Chunk]): IO[Unit] = IO.sleep(10.millis) >> ref.update(_ + batch.spans.size)
+  }
+
+  def refExporter(ref: Ref[IO, Chunk[CompletedSpan]]): SpanExporter[IO, Chunk] = new SpanExporter[IO, Chunk] {
+    def exportBatch(batch: Batch[Chunk]): IO[Unit] = ref.update(_ ++ batch.spans)
+  }
+
+  implicit def logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+  val rps = 1000
+
+  it should "not block on complete" in forAll { (builder: CompletedSpan.Builder) =>
+    val test = for {
+      ref <- Ref.of[IO, Int](0)
+      random: Random[IO] <- Random.scalaUtilRandom[IO]
+      exporter = delayedExporter(ref)
+      res <- QueuedSpanCompleter[IO](
+        TraceProcess("completer-test"),
+        exporter,
+        CompleterConfig(bufferSize = 5, batchSize = 1)
+      ).use { completer =>
+        val randomRequestTime = for {
+          rand <- random.betweenDouble(0, 1)
+          _ <- IO.sleep((1.second * rand).asInstanceOf[FiniteDuration])
+          res <- completer.complete(builder).timed
+        } yield res._1
+        List.fill(rps)(randomRequestTime).parSequence.map(_.max)
+      }
+    } yield res
+
+    val result = test.unsafeRunSync()
+    result shouldBe (<(10.millis))
+  }
+
+  it should "export all spans on shutdown" in forAll { (builder: CompletedSpan.Builder) =>
+    val test = for {
+      ref <- Ref.of[IO, Chunk[CompletedSpan]](Chunk.empty)
+      exporter = refExporter(ref)
+      _ <- QueuedSpanCompleter[IO](
+        TraceProcess("completer-test"),
+        exporter,
+        CompleterConfig(bufferSize = 50000, batchSize = 200)
+      ).use { completer =>
+        List.fill(10000)(completer.complete(builder)).sequence
+      }
+      res <- ref.get
+    } yield res
+
+    val result = test.unsafeRunSync()
+    result.size shouldBe 10000
+  }
+}

--- a/modules/core-tests/src/test/scala/trace4cats/QueuedSpanExporterSpec.scala
+++ b/modules/core-tests/src/test/scala/trace4cats/QueuedSpanExporterSpec.scala
@@ -1,0 +1,38 @@
+package trace4cats
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+import cats.effect.testkit.TestInstances
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+import fs2.Chunk
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import trace4cats.test.ArbitraryInstances._
+
+class QueuedSpanExporterSpec extends AnyFlatSpec with Matchers with TestInstances with ScalaCheckDrivenPropertyChecks {
+  behavior.of("QueuedSpanExporter")
+
+  def refExporter(ref: Ref[IO, Chunk[CompletedSpan]]): SpanExporter[IO, Chunk] = new SpanExporter[IO, Chunk] {
+    def exportBatch(batch: Batch[Chunk]): IO[Unit] = ref.update(_ ++ batch.spans)
+  }
+
+  implicit def logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+  it should "export all spans on shutdown" in forAll { (span: CompletedSpan) =>
+    val test = for {
+      ref <- Ref.of[IO, Chunk[CompletedSpan]](Chunk.empty)
+      _ <- QueuedSpanExporter[IO](50000, List("test" -> refExporter(ref))).use { exporter =>
+        List.fill(10000)(exporter.exportBatch(Batch(Chunk.singleton(span)))).sequence
+      }
+      res <- ref.get
+    } yield res
+
+    val result = test.unsafeRunSync()
+    result.size shouldBe 10000
+  }
+
+}

--- a/modules/core-tests/src/test/scala/trace4cats/QueuedSpanExporterSpec.scala
+++ b/modules/core-tests/src/test/scala/trace4cats/QueuedSpanExporterSpec.scala
@@ -26,13 +26,13 @@ class QueuedSpanExporterSpec extends AnyFlatSpec with Matchers with TestInstance
     val test = for {
       ref <- Ref.of[IO, Chunk[CompletedSpan]](Chunk.empty)
       _ <- QueuedSpanExporter[IO](50000, List("test" -> refExporter(ref))).use { exporter =>
-        List.fill(10000)(exporter.exportBatch(Batch(Chunk.singleton(span)))).sequence
+        List.fill(10001)(exporter.exportBatch(Batch(Chunk.singleton(span)))).sequence
       }
       res <- ref.get
     } yield res
 
     val result = test.unsafeRunSync()
-    result.size shouldBe 10000
+    result.size shouldBe 10001
   }
 
 }

--- a/modules/core/src/main/scala/trace4cats/QueuedSpanCompleter.scala
+++ b/modules/core/src/main/scala/trace4cats/QueuedSpanCompleter.scala
@@ -1,18 +1,14 @@
 package trace4cats
 
 import cats.Applicative
-import cats.effect.kernel.syntax.monadCancel._
 import cats.effect.kernel.syntax.spawn._
-import cats.effect.kernel.{Clock, Ref, Resource, Temporal}
+import cats.effect.kernel.{Ref, Resource, Temporal}
 import cats.effect.std.Queue
 import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import cats.syntax.monad._
 import fs2.{Chunk, Stream}
 import org.typelevel.log4cats.Logger
-
-import scala.concurrent.duration._
 
 object QueuedSpanCompleter {
   def apply[F[_]: Temporal: Logger](
@@ -22,49 +18,49 @@ object QueuedSpanCompleter {
   ): Resource[F, SpanCompleter[F]] = {
     val realBufferSize = if (config.bufferSize < config.batchSize * 5) config.batchSize * 5 else config.bufferSize
 
+    def exportBatches(stream: Stream[F, CompletedSpan]): F[Unit] =
+      stream
+        .groupWithin(config.batchSize, config.batchTimeout)
+        .evalMap { spans =>
+          Stream
+            .retry(
+              exporter.exportBatch(Batch(spans)),
+              delay = config.retryConfig.delay,
+              nextDelay = config.retryConfig.nextDelay.calc,
+              maxAttempts = config.retryConfig.maxAttempts
+            )
+            .compile
+            .drain
+            .onError { case th =>
+              Logger[F].warn(th)("Failed to export spans")
+            }
+        }
+        .compile
+        .drain
+
     for {
-      inFlight <- Resource.eval(Ref.of(0))
       hasLoggedWarn <- Resource.eval(Ref.of(false))
       queue <- Resource.eval(Queue.bounded[F, CompletedSpan](realBufferSize))
-      _ <- Resource.make {
-        Stream
-          .fromQueueUnterminated(queue)
-          .groupWithin(config.batchSize, config.batchTimeout)
-          .map(spans => Batch(spans))
-          .evalMap { batch =>
-            Stream
-              .retry(
-                exporter.exportBatch(batch),
-                delay = config.retryConfig.delay,
-                nextDelay = config.retryConfig.nextDelay.calc,
-                maxAttempts = config.retryConfig.maxAttempts
-              )
-              .compile
-              .drain
-              .onError { case th =>
-                Logger[F].warn(th)("Failed to export spans")
-              }
-              .guarantee(inFlight.update(_ - batch.spans.size))
-          }
-          .compile
-          .drain
-          .start
-      }(fiber => Clock[F].sleep(50.millis).whileM_(inFlight.get.map(_ != 0)) >> fiber.cancel)
+      _ <- exportBatches(Stream.fromQueueUnterminated(queue)).background.onFinalize(
+        exportBatches(
+          Stream
+            .repeatEval(queue.tryTake)
+            .unNoneTerminate
+        )
+      )
     } yield new SpanCompleter[F] {
       override def complete(span: CompletedSpan.Builder): F[Unit] = {
-        val enqueue = queue.offer(span.build(process)) >> inFlight.update { current =>
-          if (current == realBufferSize) current
-          else current + 1
-        }
 
-        val warnLog = hasLoggedWarn.get.ifM(
-          Logger[F].warn(s"Failed to enqueue new span, buffer is full of $realBufferSize") >> hasLoggedWarn.set(true),
-          Applicative[F].unit,
-        )
+        val warnLog = hasLoggedWarn.get
+          .map(!_)
+          .ifM(
+            Logger[F].warn(s"Failed to enqueue new span, buffer is full of $realBufferSize") >> hasLoggedWarn.set(true),
+            Applicative[F].unit,
+          )
 
-        inFlight.get
-          .map(_ == realBufferSize)
-          .ifM(warnLog, enqueue >> hasLoggedWarn.set(false))
+        queue
+          .tryOffer(span.build(process))
+          .ifM(hasLoggedWarn.set(false), warnLog)
       }
     }
   }

--- a/modules/core/src/main/scala/trace4cats/QueuedSpanCompleter.scala
+++ b/modules/core/src/main/scala/trace4cats/QueuedSpanCompleter.scala
@@ -3,11 +3,12 @@ package trace4cats
 import cats.Applicative
 import cats.effect.kernel.syntax.monadCancel._
 import cats.effect.kernel.syntax.spawn._
-import cats.effect.kernel.{Deferred, Resource, Temporal}
+import cats.effect.kernel.{Resource, Temporal}
 import cats.effect.std.Queue
 import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
+import fs2.concurrent.Channel
 import fs2.{Chunk, Stream}
 import org.typelevel.log4cats.Logger
 
@@ -19,74 +20,51 @@ object QueuedSpanCompleter {
   ): Resource[F, SpanCompleter[F]] = {
     val realBufferSize = if (config.bufferSize < config.batchSize * 5) config.batchSize * 5 else config.bufferSize
 
-    def exportBatches(stream: Stream[F, Option[CompletedSpan]]): F[Unit] =
-      Stream
-        .eval(Deferred[F, Unit])
-        .flatMap { stop =>
-          stream
-            // this allows us to optimistically terminate the stream. If the first element is `None`, then terminate
-            // immediately, if elements that are `Some` have been seen before then wait for the `groupWithin` driven
-            // export process to complete first by setting the `Deferred` and inspecting it after execution
-            .evalMapAccumulate[F, Boolean, Option[Option[CompletedSpan]]](false) {
-              case (false, None) => stop.complete(()).void.as(false -> None)
-              case (true, None) => stop.complete(()).void.as(true -> Some(None))
-              case (_, Some(s)) => Applicative[F].pure(true -> Some(Some(s)))
+    def exportBatches(stream: Stream[F, CompletedSpan]): F[Unit] =
+      stream
+        .groupWithin(config.batchSize, config.batchTimeout)
+        .evalMap { spans =>
+          Stream
+            .retry(
+              exporter.exportBatch(Batch(spans)),
+              delay = config.retryConfig.delay,
+              nextDelay = config.retryConfig.nextDelay.calc,
+              maxAttempts = config.retryConfig.maxAttempts
+            )
+            .compile
+            .drain
+            .onError { case th =>
+              Logger[F].warn(th)("Failed to export spans")
             }
-            .map(_._2)
-            .unNoneTerminate
-            .groupWithin(config.batchSize, config.batchTimeout)
-            .evalMap { spans =>
-              val allSpans = spans.collect { case Some(span) => span }
-
-              ((if (allSpans.nonEmpty)
-                  Stream
-                    .retry(
-                      exporter.exportBatch(Batch(allSpans)),
-                      delay = config.retryConfig.delay,
-                      nextDelay = config.retryConfig.nextDelay.calc,
-                      maxAttempts = config.retryConfig.maxAttempts
-                    )
-                    .compile
-                    .drain
-                    .onError { case th =>
-                      Logger[F].warn(th)("Failed to export spans")
-                    }
-                else Applicative[F].unit) >> stop.tryGet.map {
-                case None => Some(())
-                case Some(_) => None
-              }).uncancelable
-            }
+            .uncancelable
         }
-        .unNoneTerminate
         .compile
         .drain
 
     for {
-      queue <- Resource.eval(Queue.bounded[F, Option[CompletedSpan]](realBufferSize))
-      errorQueue <- Resource.eval(Queue.bounded[F, Boolean](1))
+      channel <- Resource.eval(Channel.bounded[F, CompletedSpan](realBufferSize))
+      errorQueue <- Resource.eval(Queue.bounded[F, Either[Channel.Closed, Boolean]](1))
       _ <- Stream
         .fromQueueUnterminated(errorQueue)
         .evalScan(false) {
-          case (false, false) =>
+          case (false, Right(false)) =>
             Logger[F].warn(s"Failed to enqueue new span, buffer is full of $realBufferSize").as(true)
-          case (true, false) => Applicative[F].pure(true)
-          case (_, true) => Applicative[F].pure(false)
+          case (false, Left(_)) =>
+            Logger[F].warn(s"Failed to enqueue new span, channel is closed").as(true)
+          case (true, _) => Applicative[F].pure(true)
+          case (_, Right(true)) => Applicative[F].pure(false)
         }
         .compile
         .drain
         .background
-      _ <- exportBatches(Stream.fromQueueUnterminated(queue)).uncancelable.background
-        .onFinalize(
-          Logger[F].info("Shutting down queued span completer") >> exportBatches(
-            Stream.repeatEval(queue.tryTake).map(_.flatten)
-          )
-        )
-      _ <- Resource.onFinalize(queue.offer(None))
+      _ <- exportBatches(channel.stream).uncancelable.background
+        .onFinalize(Logger[F].info("Shut down queued span completer"))
+      _ <- Resource.onFinalize(channel.close.void)
     } yield new SpanCompleter[F] {
       override def complete(span: CompletedSpan.Builder): F[Unit] =
-        queue
-          .tryOffer(Some(span.build(process)))
-          .flatMap(errorQueue.tryOffer)
+        channel
+          .trySend(span.build(process))
+          .flatMap(errorQueue.tryOffer(_).start.void)
           .void
     }
   }

--- a/modules/core/src/main/scala/trace4cats/QueuedSpanCompleter.scala
+++ b/modules/core/src/main/scala/trace4cats/QueuedSpanCompleter.scala
@@ -2,12 +2,13 @@ package trace4cats
 
 import cats.Applicative
 import cats.effect.kernel.syntax.spawn._
-import cats.effect.kernel.{Ref, Resource, Temporal}
+import cats.effect.kernel.{Deferred, Ref, Resource, Temporal}
 import cats.effect.std.Queue
 import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import fs2.{Chunk, Stream}
+import cats.effect.kernel.syntax.monadCancel._
 import org.typelevel.log4cats.Logger
 
 object QueuedSpanCompleter {
@@ -18,7 +19,7 @@ object QueuedSpanCompleter {
   ): Resource[F, SpanCompleter[F]] = {
     val realBufferSize = if (config.bufferSize < config.batchSize * 5) config.batchSize * 5 else config.bufferSize
 
-    def exportBatches(stream: Stream[F, CompletedSpan]): F[Unit] =
+    def exportBatches(stream: Stream[F, CompletedSpan], signal: Deferred[F, Either[Throwable, Unit]]): F[Unit] =
       stream
         .groupWithin(config.batchSize, config.batchTimeout)
         .evalMap { spans =>
@@ -34,20 +35,27 @@ object QueuedSpanCompleter {
             .onError { case th =>
               Logger[F].warn(th)("Failed to export spans")
             }
+            .uncancelable
         }
+        .interruptWhen(signal)
         .compile
         .drain
 
     for {
       hasLoggedWarn <- Resource.eval(Ref.of(false))
+      shutdownSignal <- Resource.eval(Deferred[F, Either[Throwable, Unit]])
       queue <- Resource.eval(Queue.bounded[F, CompletedSpan](realBufferSize))
-      _ <- exportBatches(Stream.fromQueueUnterminated(queue)).background.onFinalize(
-        exportBatches(
-          Stream
-            .repeatEval(queue.tryTake)
-            .unNoneTerminate
+      _ <- exportBatches(Stream.fromQueueUnterminated(queue), shutdownSignal).uncancelable.background.onFinalize(
+        Deferred[F, Either[Throwable, Unit]].flatMap(
+          exportBatches(
+            Stream
+              .repeatEval(queue.tryTake)
+              .unNoneTerminate,
+            _
+          )
         )
       )
+      _ <- Resource.make(Applicative[F].unit)(_ => shutdownSignal.complete(Right(())).void)
     } yield new SpanCompleter[F] {
       override def complete(span: CompletedSpan.Builder): F[Unit] = {
 

--- a/modules/core/src/main/scala/trace4cats/QueuedSpanExporter.scala
+++ b/modules/core/src/main/scala/trace4cats/QueuedSpanExporter.scala
@@ -46,5 +46,4 @@ object QueuedSpanExporter {
       .parTraverse(buffer)
       .map(_.combineAll)
   }
-
 }

--- a/modules/core/src/main/scala/trace4cats/QueuedSpanExporter.scala
+++ b/modules/core/src/main/scala/trace4cats/QueuedSpanExporter.scala
@@ -1,15 +1,13 @@
 package trace4cats
 
 import cats.Parallel
-import cats.effect.kernel.{Clock, Ref, Resource, Temporal}
+import cats.effect.kernel.{Deferred, Resource, Temporal}
 import cats.effect.std.Queue
 import cats.effect.syntax.monadCancel._
 import cats.effect.syntax.spawn._
 import cats.effect.syntax.temporal._
-import cats.syntax.flatMap._
 import cats.syntax.foldable._
 import cats.syntax.functor._
-import cats.syntax.monad._
 import cats.syntax.parallel._
 import fs2.{Chunk, Stream}
 import org.typelevel.log4cats.Logger
@@ -22,25 +20,29 @@ object QueuedSpanExporter {
     exporters: List[(String, SpanExporter[F, Chunk])],
     enqueueTimeout: FiniteDuration = 200.millis
   ): Resource[F, StreamSpanExporter[F]] = {
-    def buffer(exporter: SpanExporter[F, Chunk]): Resource[F, StreamSpanExporter[F]] =
+    def buffer(exporter: SpanExporter[F, Chunk]): Resource[F, StreamSpanExporter[F]] = {
+      def exportBatches(
+        stream: Stream[F, Batch[Chunk]],
+        signal: Option[Deferred[F, Either[Throwable, Unit]]]
+      ): F[Unit] = {
+        val exportStream = stream.evalMap(exporter.exportBatch(_).uncancelable)
+
+        signal.fold(exportStream)(exportStream.interruptWhen(_)).compile.drain
+      }
+
       for {
-        inFlight <- Resource.eval(Ref.of[F, Int](0))
         queue <- Resource.eval(Queue.bounded[F, Batch[Chunk]](bufferSize))
-        _ <- Resource.make(
-          Stream
-            .fromQueueUnterminated(queue)
-            .evalMap(exporter.exportBatch(_).guarantee(inFlight.update(_ - 1)))
-            .compile
-            .drain
-            .start
-        )(fiber => Clock[F].sleep(50.millis).whileM_(inFlight.get.map(_ != 0)) >> fiber.cancel)
+        shutdownSignal <- Resource.eval(Deferred[F, Either[Throwable, Unit]])
+        _ <- exportBatches(Stream.fromQueueUnterminated(queue), Some(shutdownSignal)).uncancelable.background
+          .onFinalize(exportBatches(Stream.repeatEval(queue.tryTake).unNoneTerminate, None))
+        _ <- Resource.onFinalize(shutdownSignal.complete(Right(())).void)
       } yield new StreamSpanExporter[F] {
         override def exportBatch(batch: Batch[Chunk]): F[Unit] =
-          (queue.offer(batch) >> inFlight.update { current =>
-            if (current == bufferSize) current
-            else current + 1
-          }).timeoutTo(enqueueTimeout, Logger[F].warn(s"Failed to enqueue span batch in $enqueueTimeout"))
+          queue
+            .offer(batch)
+            .timeoutTo(enqueueTimeout, Logger[F].warn(s"Failed to enqueue span batch in $enqueueTimeout"))
       }
+    }
 
     exporters
       .map { case (name, exporter) =>


### PR DESCRIPTION
The queued span completer was causing contention around the `Ref` for
recording in flight requests. Seeing as this was only really used to
ensure that the completer can be shut down properly, there's a better
way of doing this new we have CE3.