### PR TITLE
Make parsing of Google's X-Cloud-Trace-Context less strict

### DIFF
--- a/modules/kernel-tests/src/test/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeadersSpec.scala
+++ b/modules/kernel-tests/src/test/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeadersSpec.scala
@@ -60,4 +60,24 @@ class GoogleCloudTraceToHeadersSpec
     assert(cloudTrace.toContext(headers).isDefined)
     assert(Eq.eqv(cloudTrace.toContext(headers), expected))
   }
+
+  it should "decode example Cloud Trace headers without the `;o=` part" in {
+    val spanId = 2205310701640571284L
+    val headers = TraceHeaders.of("X-Cloud-Trace-Context" -> s"105445aa7843bc8bf206b12000100000/$spanId")
+
+    val expected = for {
+      traceId <- TraceId.fromHexString("105445aa7843bc8bf206b12000100000")
+      spanId <- SpanId.fromHexString(spanId.toHexString)
+    } yield SpanContext(
+      traceId,
+      spanId,
+      None,
+      TraceFlags(sampled = SampleDecision.Drop),
+      TraceState.empty,
+      isRemote = true
+    )
+
+    assert(cloudTrace.toContext(headers).isDefined)
+    assert(Eq.eqv(cloudTrace.toContext(headers), expected))
+  }
 }

--- a/modules/kernel-tests/src/test/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeadersSpec.scala
+++ b/modules/kernel-tests/src/test/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeadersSpec.scala
@@ -72,7 +72,7 @@ class GoogleCloudTraceToHeadersSpec
       traceId,
       spanId,
       None,
-      TraceFlags(sampled = SampleDecision.Drop),
+      TraceFlags(sampled = SampleDecision.Include),
       TraceState.empty,
       isRemote = true
     )

--- a/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
+++ b/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
@@ -50,7 +50,7 @@ private[trace4cats] object GoogleCloudTraceToHeaders {
         traceId = traceId,
         spanId = spanId,
         parent = none,
-        traceFlags = TraceFlags(if (enabled == Some("1")) SampleDecision.Include else SampleDecision.Drop),
+        traceFlags = TraceFlags(if (enabled == Some("0")) SampleDecision.Drop else SampleDecision.Include),
         traceState = TraceState.empty,
         isRemote = true
       )

--- a/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
+++ b/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
@@ -50,8 +50,8 @@ private[trace4cats] object GoogleCloudTraceToHeaders {
         spanId = spanId,
         parent = none,
         traceFlags = TraceFlags(Option(enabled) match { // `enabled` can be `null`
-          case Some("0") => SampleDecision.Drop
-          case _ => SampleDecision.Include
+          case Some("1") | None => SampleDecision.Include
+          case _ => SampleDecision.Drop
         }),
         traceState = TraceState.empty,
         isRemote = true

--- a/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
+++ b/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
@@ -41,10 +41,10 @@ private[trace4cats] object GoogleCloudTraceToHeaders {
     case headerPattern(traceId, spanId, enabled) =>
       for {
         traceId <- Either.fromOption(TraceId.fromHexString(traceId), new Exception("invalid trace ID"))
-        spanId <- Either.fromOption(
-          Either.catchNonFatal(BigInt(spanId)).toOption.flatMap(bi => SpanId.fromHexString("%016x".format(bi))),
-          new Exception("invalid span ID")
-        )
+        spanId <- Either
+          .catchNonFatal(BigInt(spanId))
+          .leftMap(new Exception("invalid span ID", _))
+          .flatMap(bi => Either.fromOption(SpanId.fromHexString("%016x".format(bi)), new Exception("invalid span ID")))
       } yield SpanContext(
         traceId = traceId,
         spanId = spanId,

--- a/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
+++ b/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
@@ -42,7 +42,7 @@ private[trace4cats] object GoogleCloudTraceToHeaders {
       for {
         traceId <- Either.fromOption(TraceId.fromHexString(traceId), new Exception("invalid trace ID"))
         spanId <- Either.fromOption(
-          SpanId.fromHexString("%016x".format(BigInt(spanId))),
+          Either.catchNonFatal(BigInt(spanId)).toOption.flatMap(bi => SpanId.fromHexString("%016x".format(bi))),
           new Exception("invalid span ID")
         )
       } yield SpanContext(

--- a/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
+++ b/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
@@ -28,12 +28,12 @@ private[trace4cats] object GoogleCloudTraceToHeaders {
   // from https://cloud.google.com/trace/docs/setup
   val headerPattern =
     """(?xi)
-      |([^\/]+) # trace ID
+      |([^\/]+)    # trace ID
       |\/
-      |([^;]+)       # span ID (unsigned decimal)
+      |([^;]+)     # span ID (unsigned decimal)
       |(?:
       |;
-      |o=(.*)     # trace enabled flag
+      |o=(.*)      # trace enabled flag
       |)?
       |""".stripMargin.r
 

--- a/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
+++ b/modules/kernel/src/main/scala/trace4cats/kernel/headers/GoogleCloudTraceToHeaders.scala
@@ -8,8 +8,6 @@ import org.typelevel.ci._
 import trace4cats.kernel.ToHeaders
 import trace4cats.model._
 
-import scala.Option
-
 private[trace4cats] class GoogleCloudTraceToHeaders extends ToHeaders {
   import GoogleCloudTraceToHeaders._
 


### PR DESCRIPTION
The `;o=...` part is supposed to be optional