### PR TITLE
Preserve nanosecond precision

### DIFF
--- a/modules/testkit/src/main/scala/trace4cats/test/ArbitraryInstances.scala
+++ b/modules/testkit/src/main/scala/trace4cats/test/ArbitraryInstances.scala
@@ -13,7 +13,12 @@ trait ArbitraryInstances extends ArbitraryAttributeValues {
 
   implicit val doubleArb: Arbitrary[Double] = Arbitrary(Gen.chooseNum(-1000.0, 1000.0).map(_ + 0.5))
 
-  implicit val instantArb: Arbitrary[Instant] = Arbitrary(Gen.choose(0L, 1593882556588L).map(Instant.ofEpochMilli))
+  implicit val instantArb: Arbitrary[Instant] = Arbitrary(
+    Gen
+      .choose(0L, 1593882556588L)
+      .map(Instant.ofEpochMilli)
+      .flatMap(instant => Gen.choose[Long](0, 999999).map(instant.plusNanos))
+  )
 
   implicit val stringArb: Arbitrary[String] = Arbitrary(for {
     size <- Gen.choose(1, 5)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,19 +2,19 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val caseInsensitive = "1.2.0"
-    val cats = "2.8.0"
-    val catsEffect = "3.3.14"
-    val collectionCompat = "2.8.1"
+    val caseInsensitive = "1.4.0"
+    val cats = "2.9.0"
+    val catsEffect = "3.5.0"
+    val collectionCompat = "2.11.0"
     val commonsCodec = "1.15"
-    val fs2 = "3.2.14"
+    val fs2 = "3.7.0"
     val hotswapRef = "0.2.2"
     val kittens = "2.3.2"
-    val log4cats = "2.4.0"
+    val log4cats = "2.6.0"
     val slf4j = "1.7.36"
     val scala212 = "2.12.16"
     val scala213 = "2.13.8"
-    val scala3 = "3.1.3"
+    val scala3 = "3.3.0"
 
     val catsTestkitScalatest = "2.1.5"
     val disciplineScalatest = "2.2.0"


### PR DESCRIPTION
As cats-effect 3.4 offers more than millisecond precision, ensure to not convert to millis in between.

Bumps a few dependencies on the way as Scala 3 had to be bumped anyway for new CE versions.

Relates to https://github.com/trace4cats/trace4cats-jaeger/pull/175 and https://github.com/trace4cats/trace4cats-opentelemetry/pull/297 that ensure the gained precision is properly encoded.