### PR TITLE
Fix module dependencies for iolocal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ lazy val meta =
 lazy val iolocal = (project in file("modules/iolocal"))
   .settings(publishSettings)
   .settings(name := "trace4cats-iolocal")
-  .dependsOn(core, `context-utils`, `context-utils-laws` % "compile->compile;test->test", testkit % Test)
+  .dependsOn(core, `context-utils`, `context-utils-laws` % "test->compile,test", testkit % Test)
 
 lazy val fs2 = (project in file("modules/fs2"))
   .settings(publishSettings)


### PR DESCRIPTION
By using an unfortunate sbt dependency projection, the iolocal module pulled test libs like scalacheck into the compile scope and made apps depending on iolocal have those on their runtime classpath.