### PR TITLE
Improvements to `Ask` & `Local`

### DIFF
--- a/modules/context-utils/src/main/scala/trace4cats/context/Ask.scala
+++ b/modules/context-utils/src/main/scala/trace4cats/context/Ask.scala
@@ -3,6 +3,7 @@ package trace4cats.context
 import cats.{~>, Monad}
 import cats.syntax.all._
 import trace4cats.optics.Getter
+import trace4cats.context.internal.TupleAskInstances
 
 trait Ask[F[_], R] extends ContextRoot { self =>
   def F: Monad[F]
@@ -18,7 +19,7 @@ trait Ask[F[_], R] extends ContextRoot { self =>
 
 }
 
-object Ask {
+object Ask extends TupleAskInstances {
 
   def apply[F[_], R](implicit ev: Ask[F, R]): Ask[F, R] = ev
 

--- a/modules/context-utils/src/main/scala/trace4cats/context/Ask.scala
+++ b/modules/context-utils/src/main/scala/trace4cats/context/Ask.scala
@@ -1,6 +1,7 @@
 package trace4cats.context
 
 import cats.{~>, Monad}
+import cats.syntax.all._
 import trace4cats.optics.Getter
 
 trait Ask[F[_], R] extends ContextRoot { self =>
@@ -11,17 +12,21 @@ trait Ask[F[_], R] extends ContextRoot { self =>
   def access[A](f: R => A): F[A] = F.map(ask)(f)
   def accessF[A](f: R => F[A]): F[A] = F.flatMap(ask)(f)
 
-  def zoom[R1](g: Getter[R, R1]): Ask[F, R1] = new Ask[F, R1] {
-    val F: Monad[F] = self.F
-    def ask[R2 >: R1]: F[R2] = self.access(g.get)
-  }
+  def zoom[R1](g: Getter[R, R1]): Ask[F, R1] = Ask.make(self.access(g.get))(self.F)
 
-  def mapK[G[_]: Monad](fk: F ~> G): Ask[G, R] = new Ask[G, R] {
-    val F: Monad[G] = implicitly
-    def ask[R1 >: R]: G[R1] = fk(self.ask[R1])
-  }
+  def mapK[G[_]: Monad](fk: F ~> G): Ask[G, R] = Ask.make(fk(self.ask[R]))
+
 }
 
 object Ask {
+
   def apply[F[_], R](implicit ev: Ask[F, R]): Ask[F, R] = ev
+
+  def make[F[_]: Monad, A](f: F[A]): Ask[F, A] = new Ask[F, A] {
+    override def F: Monad[F] = Monad[F]
+
+    def ask[E2 >: A]: F[E2] = f.widen
+
+  }
+
 }

--- a/modules/context-utils/src/main/scala/trace4cats/context/internal/TupleAskInstances.scala
+++ b/modules/context-utils/src/main/scala/trace4cats/context/internal/TupleAskInstances.scala
@@ -1,0 +1,74 @@
+package trace4cats.context.internal
+
+import cats.Monad
+import cats.syntax.all._
+
+import trace4cats.context.Ask
+
+// scalafmt: { maxColumn = 500 }
+trait TupleAskInstances {
+
+  implicit def Tuple2Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *]]: Ask[Z, (A, B)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask).tupled)
+
+  implicit def Tuple3Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *]]: Ask[Z, (A, B, C)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask).tupled)
+
+  implicit def Tuple4Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *]]: Ask[Z, (A, B, C, D)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask).tupled)
+
+  implicit def Tuple5Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *]]: Ask[Z, (A, B, C, D, E)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask).tupled)
+
+  implicit def Tuple6Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask).tupled)
+
+  implicit def Tuple7Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask).tupled)
+
+  implicit def Tuple8Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask).tupled)
+
+  implicit def Tuple9Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask).tupled)
+
+  implicit def Tuple10Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask).tupled)
+
+  implicit def Tuple11Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask).tupled)
+
+  implicit def Tuple12Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask).tupled)
+
+  implicit def Tuple13Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask).tupled)
+
+  implicit def Tuple14Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask).tupled)
+
+  implicit def Tuple15Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *], O: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask, Ask[Z, O].ask).tupled)
+
+  implicit def Tuple16Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *], O: Ask[Z, *], P: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask, Ask[Z, O].ask, Ask[Z, P].ask).tupled)
+
+  implicit def Tuple17Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *], O: Ask[Z, *], P: Ask[Z, *], Q: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask, Ask[Z, O].ask, Ask[Z, P].ask, Ask[Z, Q].ask).tupled)
+
+  implicit def Tuple18Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *], O: Ask[Z, *], P: Ask[Z, *], Q: Ask[Z, *], R: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask, Ask[Z, O].ask, Ask[Z, P].ask, Ask[Z, Q].ask, Ask[Z, R].ask).tupled)
+
+  implicit def Tuple19Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *], O: Ask[Z, *], P: Ask[Z, *], Q: Ask[Z, *], R: Ask[Z, *], S: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask, Ask[Z, O].ask, Ask[Z, P].ask, Ask[Z, Q].ask, Ask[Z, R].ask, Ask[Z, S].ask).tupled)
+
+  implicit def Tuple20Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *], O: Ask[Z, *], P: Ask[Z, *], Q: Ask[Z, *], R: Ask[Z, *], S: Ask[Z, *], T: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask, Ask[Z, O].ask, Ask[Z, P].ask, Ask[Z, Q].ask, Ask[Z, R].ask, Ask[Z, S].ask, Ask[Z, T].ask).tupled)
+
+  implicit def Tuple21Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *], O: Ask[Z, *], P: Ask[Z, *], Q: Ask[Z, *], R: Ask[Z, *], S: Ask[Z, *], T: Ask[Z, *], U: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask, Ask[Z, O].ask, Ask[Z, P].ask, Ask[Z, Q].ask, Ask[Z, R].ask, Ask[Z, S].ask, Ask[Z, T].ask, Ask[Z, U].ask).tupled)
+
+  implicit def Tuple22Ask[Z[_]: Monad, A: Ask[Z, *], B: Ask[Z, *], C: Ask[Z, *], D: Ask[Z, *], E: Ask[Z, *], F: Ask[Z, *], G: Ask[Z, *], H: Ask[Z, *], I: Ask[Z, *], J: Ask[Z, *], K: Ask[Z, *], L: Ask[Z, *], M: Ask[Z, *], N: Ask[Z, *], O: Ask[Z, *], P: Ask[Z, *], Q: Ask[Z, *], R: Ask[Z, *], S: Ask[Z, *], T: Ask[Z, *], U: Ask[Z, *], V: Ask[Z, *]]: Ask[Z, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
+    Ask.make((Ask[Z, A].ask, Ask[Z, B].ask, Ask[Z, C].ask, Ask[Z, D].ask, Ask[Z, E].ask, Ask[Z, F].ask, Ask[Z, G].ask, Ask[Z, H].ask, Ask[Z, I].ask, Ask[Z, J].ask, Ask[Z, K].ask, Ask[Z, L].ask, Ask[Z, M].ask, Ask[Z, N].ask, Ask[Z, O].ask, Ask[Z, P].ask, Ask[Z, Q].ask, Ask[Z, R].ask, Ask[Z, S].ask, Ask[Z, T].ask, Ask[Z, U].ask, Ask[Z, V].ask).tupled)
+
+}

--- a/modules/context-utils/src/main/scala/trace4cats/context/syntax.scala
+++ b/modules/context-utils/src/main/scala/trace4cats/context/syntax.scala
@@ -1,0 +1,15 @@
+package trace4cats.context
+
+object syntax {
+
+  implicit class LocalOps[F[_], A](val fa: F[A]) extends AnyVal {
+
+    def local[E](f: E => E)(implicit local: Local[F, E]): F[A] =
+      local.local(fa)(f)
+
+    def scope[E](e: E)(implicit local: Local[F, E]): F[A] =
+      local.scope(fa)(e)
+
+  }
+
+}

--- a/modules/context-utils/src/main/scala/trace4cats/context/syntax.scala
+++ b/modules/context-utils/src/main/scala/trace4cats/context/syntax.scala
@@ -12,4 +12,11 @@ object syntax {
 
   }
 
+  implicit class ProvideOps[F[_], A](val fa: F[A]) extends AnyVal {
+
+    def provide[Low[_], E](e: E)(implicit provide: Provide[Low, F, E]): Low[A] =
+      provide.provide(fa)(e)
+
+  }
+
 }

--- a/modules/core/src/main/scala/trace4cats/implicits.scala
+++ b/modules/core/src/main/scala/trace4cats/implicits.scala
@@ -1,0 +1,19 @@
+package trace4cats
+
+import cats.Monad
+import trace4cats.context.Ask
+
+object implicits {
+
+  type SpanContextAsk[F[_]] = Ask[F, SpanContext]
+
+  implicit def SpanContextAsk[F[_]: Monad: Trace.WithContext]: Ask[F, SpanContext] =
+    Ask.make(Trace.WithContext[F].context)
+
+  implicit def TraceIdAsk[F[_]: SpanContextAsk]: Ask[F, TraceId] =
+    Ask[F, SpanContext].zoom(_.traceId)
+
+  implicit def SpanIdAsk[F[_]: SpanContextAsk]: Ask[F, SpanId] =
+    Ask[F, SpanContext].zoom(_.spanId)
+
+}


### PR DESCRIPTION
## 💻 How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## 🚀 What's included in this PR?

### New method `Ask.make` to ease creating a new `Ask` instance

```diff
- implicit def instance[F[_]: Monad: Trace.WithContext]: Ask[F, SpanContext] = new Ask[F, SpanContext] {
-
-   override def F: Monad[F] = Monad[F]
-
-   override def ask[R1 >: SpanContext]: F[R1] = Trace.WithContext[F].context.widen
-
- }
+ implicit def instance[F[_]: Monad: Trace.WithContext]: Ask[F, SpanContext] = Ask.make(Trace.WithContext[F].context)
```

### Add `Ask` instances for `Tuple` types

Provide automatic derivation of `Ask` instances for tuple types if we have instances for underlying types.

### Provide implicit syntax for `Local`

```diff
- Local[F, Something]
-   .local(
-     myService.doSomething()
-   )(_.update(withSomething))
+ myService.doSomething()
+   .local(_.update(withSomething))
```

### Provide `Ask` instances for `SpanContext`, `TraceId` & `SpanId`