### PR TITLE
Fix span completer freezing issue

### DIFF
--- a/modules/core/src/main/scala/trace4cats/QueuedSpanCompleter.scala
+++ b/modules/core/src/main/scala/trace4cats/QueuedSpanCompleter.scala
@@ -33,7 +33,7 @@ object QueuedSpanCompleter {
             )
             .compile
             .drain
-            .onError { case th =>
+            .handleErrorWith { th =>
               Logger[F].warn(th)("Failed to export spans")
             }
             .uncancelable


### PR DESCRIPTION
`onError` in the `QueuedSpanCompleter.exportBatches` was replaced with `handleErrorWith` not to fail the source stream otherwise the `SpanCompleter` will receive spans but will not be able to export them.